### PR TITLE
Extract class methods and properties in TypeScript parser

### DIFF
--- a/src/parsers/treesitter/queries/typescript.scm
+++ b/src/parsers/treesitter/queries/typescript.scm
@@ -113,3 +113,29 @@
 (decorator
   (call_expression
     function: (identifier) @decorator_call_id))
+
+; === Class methods ===
+
+; method() {}, constructor() {}, get x() {}, set x(v) {}, static m() {}, async m() {}
+(method_definition
+  name: (property_identifier) @method_name) @method_node
+
+; #privateMethod() {}
+(method_definition
+  name: (private_property_identifier) @private_method_name) @private_method_node
+
+; === Class properties/fields ===
+
+; prop: Type = value
+(public_field_definition
+  name: (property_identifier) @field_name) @field_node
+
+; #privateProp: Type
+(public_field_definition
+  name: (private_property_identifier) @private_field_name) @private_field_node
+
+; === Abstract methods ===
+
+; abstract method(): void
+(abstract_method_signature
+  name: (property_identifier) @abstract_method_name) @abstract_method_node


### PR DESCRIPTION
## Problem

TypeScript parser only indexed top-level declarations (classes, interfaces, functions, etc.).
Class methods, properties, and abstract members were invisible to `search`, `symbol`, and `outline` commands.

## Solution

Added 5 tree-sitter query patterns to capture class members:
- `method_definition` (public and `#private`)
- `public_field_definition` (public and `#private`)
- `abstract_method_signature`

Filtering via `is_inside_class_body()` ensures object literal methods are excluded from the index.

## Results

Tested on a real-world TypeScript project (~9k symbols before):

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| Total symbols | 9,004 | 13,638 | **+51%** |
| Functions | 174 | 2,054 | +1,880 |
| Properties | 0 | 2,754 | +2,754 |

## Changes

- `src/parsers/treesitter/queries/typescript.scm` — 5 new capture patterns for class members
- `src/parsers/treesitter/typescript.rs` — capture indices, `emit_class_member()` helper, `is_inside_class_body()` filter
- 6 new tests: methods, getters/setters, fields, abstract methods, object literals (negative), `#private` members