### PR TITLE
Add Matlab language support (28th language)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,7 @@ dependencies = [
  "tree-sitter-java",
  "tree-sitter-kotlin-ng",
  "tree-sitter-lua",
+ "tree-sitter-matlab",
  "tree-sitter-objc",
  "tree-sitter-php",
  "tree-sitter-proto",
@@ -1631,6 +1632,16 @@ name = "tree-sitter-lua"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8daaf5f4235188a58603c39760d5fa5d4b920d36a299c934adddae757f32a10c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-matlab"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e8d8831a78547f54860dd8467166b1ab0c466d03d43c4bb447af55c024281f7"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ tree-sitter-bash = "0.25"
 tree-sitter-sql = "0.0.2"
 tree-sitter-groovy = "0.1"
 tree-sitter-r = "1.2"
+tree-sitter-matlab = "1.3"
 fs2 = "0.4.3"
 
 [build-dependencies]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ast-index v3.26.2
 
-Fast code search CLI for 27 programming languages. Native Rust implementation.
+Fast code search CLI for 28 programming languages. Native Rust implementation.
 
 ## Supported Projects
 
@@ -19,6 +19,7 @@ Fast code search CLI for 27 programming languages. Native Rust implementation.
 | Scripting | Lua, Bash | `.lua`, `.sh`, `.bash`, `.zsh` |
 | Functional | Elixir | `.ex`, `.exs` |
 | Data | SQL, R | `.sql`, `.r`, `.R` |
+| Scientific | Matlab | `.m` |
 | JVM | Groovy | `.groovy`, `.gradle` |
 
 Project type is auto-detected.

--- a/plugin/skills/ast-index/references/matlab-commands.md
+++ b/plugin/skills/ast-index/references/matlab-commands.md
@@ -1,0 +1,126 @@
+# Matlab Commands Reference
+
+ast-index supports parsing and indexing Matlab source files (`.m`).
+
+## Supported Elements
+
+| Matlab Element | Symbol Kind | Example |
+|----------------|-------------|---------|
+| `classdef ClassName` | Class | `Vehicle` → Class |
+| `function name` | Function | `calculate` → Function |
+| `properties` block members | Property | `Speed` → Property |
+| `enumeration` members | Constant | `Red` → Constant |
+| `events` block members | Property | `ButtonPressed` → Property |
+
+## File Detection
+
+`.m` files are shared between Matlab and Objective-C. ast-index automatically detects the language by inspecting file content:
+
+- **Matlab markers**: `classdef`, `function`, `%` comments
+- **ObjC markers**: `#import`, `@interface`, `//` comments
+
+Mixed projects with both Matlab and ObjC `.m` files are handled correctly.
+
+## Core Commands
+
+### Search Classes
+
+Find Matlab class definitions:
+
+```bash
+ast-index class "Vehicle"           # Find Vehicle class
+ast-index class "handle"            # Find handle-derived classes
+ast-index implementations "handle"  # Find all classes extending handle
+```
+
+### Search Functions
+
+Find functions and methods:
+
+```bash
+ast-index symbol "calculate"        # Find functions containing "calculate"
+ast-index callers "processData"     # Find callers of processData
+```
+
+### Class Hierarchy
+
+```bash
+ast-index hierarchy "Vehicle"       # Show Vehicle class hierarchy
+ast-index implementations "handle"  # Find all handle subclasses
+```
+
+### File Analysis
+
+Show file structure:
+
+```bash
+ast-index outline "Vehicle.m"       # Show class, properties, methods
+ast-index usages "Vehicle"          # Find usages of Vehicle
+```
+
+## Example Workflow
+
+```bash
+# 1. Index Matlab project
+cd /path/to/matlab/project
+ast-index rebuild
+
+# 2. Check index statistics
+ast-index stats
+
+# 3. Find all classes
+ast-index search "classdef"
+
+# 4. Find all functions
+ast-index search "function"
+
+# 5. Show file structure
+ast-index outline "Vehicle.m"
+
+# 6. Find implementations of a base class
+ast-index implementations "handle"
+
+# 7. Find usages
+ast-index usages "Vehicle"
+```
+
+## Indexed Matlab Patterns
+
+### Class Definition with Inheritance
+
+```matlab
+classdef Vehicle < handle
+    properties
+        Make
+        Model
+        Year
+    end
+    methods
+        function obj = Vehicle(make, model, year)
+            obj.Make = make;
+            obj.Model = model;
+            obj.Year = year;
+        end
+    end
+    enumeration
+        Car, Truck, SUV
+    end
+end
+```
+
+Indexed as:
+- `Vehicle` [class] extends `handle`
+- `Make`, `Model`, `Year` [property] member_of `Vehicle`
+- `Vehicle` [function] member_of `Vehicle` (constructor)
+- `Car`, `Truck`, `SUV` [constant] member_of `Vehicle`
+
+### Standalone Function
+
+```matlab
+function result = myFunction(x, y)
+    result = x + y;
+end
+```
+
+Indexed as:
+- `myFunction` [function]

--- a/src/commands/files.rs
+++ b/src/commands/files.rs
@@ -241,7 +241,10 @@ pub fn cmd_outline(root: &Path, file: &str) -> Result<()> {
         found = outline_via_treesitter(&content, crate::parsers::FileType::CSharp, &[SymbolKind::Import])?;
     } else if ext == "proto" {
         found = outline_via_treesitter(&content, crate::parsers::FileType::Proto, &[])?;
-    } else if ext == "m" || ext == "mm" {
+    } else if ext == "m" {
+        let ft = crate::parsers::FileType::detect_m_file_type(&content);
+        found = outline_via_treesitter(&content, ft, &[SymbolKind::Import])?;
+    } else if ext == "mm" {
         found = outline_via_treesitter(&content, crate::parsers::FileType::ObjC, &[SymbolKind::Import])?;
     } else {
         // Kotlin (default fallback — existing regex logic)

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -56,6 +56,7 @@ pub enum ProjectType {
     PHP,       // PHP - composer.json
     Ruby,      // Ruby - Gemfile, *.gemspec
     Scala,     // Scala - build.sbt
+    Matlab,    // Matlab - .m files with classdef/function
     Mixed,     // Multiple platforms present
     Unknown,
 }
@@ -78,6 +79,7 @@ impl ProjectType {
             ProjectType::PHP => "PHP",
             ProjectType::Ruby => "Ruby",
             ProjectType::Scala => "Scala",
+            ProjectType::Matlab => "Matlab",
             ProjectType::Mixed => "Mixed",
             ProjectType::Unknown => "Unknown",
         }
@@ -102,6 +104,7 @@ impl ProjectType {
             "php" | "laravel" => Some(ProjectType::PHP),
             "ruby" | "rb" | "rails" => Some(ProjectType::Ruby),
             "scala" | "sbt" => Some(ProjectType::Scala),
+            "matlab" | "m" => Some(ProjectType::Matlab),
             _ => None,
         }
     }
@@ -331,11 +334,50 @@ pub fn detect_project_type(root: &Path) -> ProjectType {
     // Scala project detection
     let has_scala = root.join("build.sbt").exists();
 
+    // Matlab project detection: look for startup.m, pathdef.m, + package dirs,
+    // or .m files containing classdef/function keywords (not ObjC markers)
+    let has_matlab = root.join("startup.m").exists()
+        || root.join("pathdef.m").exists()
+        || fs::read_dir(root)
+            .map(|entries| {
+                entries
+                    .filter_map(|e| e.ok())
+                    .any(|e| {
+                        let name = e.file_name();
+                        let name = name.to_string_lossy();
+                        // + prefix directories are Matlab package directories
+                        name.starts_with('+')
+                            && e.path().is_dir()
+                    })
+            })
+            .unwrap_or(false)
+        || {
+            // Sample a .m file to check for Matlab keywords
+            fs::read_dir(root)
+                .map(|entries| {
+                    entries
+                        .filter_map(|e| e.ok())
+                        .filter(|e| e.path().extension().map(|ext| ext == "m").unwrap_or(false))
+                        .take(3)
+                        .any(|e| {
+                            fs::read_to_string(e.path())
+                                .map(|content| {
+                                    let trimmed = content.trim_start();
+                                    trimmed.starts_with("classdef")
+                                        || trimmed.starts_with("function")
+                                        || trimmed.starts_with('%')
+                                })
+                                .unwrap_or(false)
+                        })
+                })
+                .unwrap_or(false)
+        };
+
     // Count how many platforms are detected
     let count = [
         has_gradle, has_swift, has_perl, has_frontend, has_python, has_go,
         has_rust, has_bazel, has_bsl, has_csharp, has_cpp, has_dart,
-        has_php, has_ruby, has_scala,
+        has_php, has_ruby, has_scala, has_matlab,
     ]
         .iter()
         .filter(|&&x| x)
@@ -373,6 +415,8 @@ pub fn detect_project_type(root: &Path) -> ProjectType {
         ProjectType::Ruby
     } else if has_scala {
         ProjectType::Scala
+    } else if has_matlab {
+        ProjectType::Matlab
     } else {
         ProjectType::Unknown
     }
@@ -415,9 +459,13 @@ fn parse_file(root: &Path, file_path: &Path) -> Result<ParsedFile> {
 
     let content = fs::read_to_string(file_path)?;
 
-    // Detect file type by extension
+    // Detect file type by extension, with content-based sniffing for .m files
     let ext = file_path.extension().and_then(|e| e.to_str()).unwrap_or("");
-    let file_type = match parsers::FileType::from_extension(ext) {
+    let file_type = match if ext == "m" {
+        Some(parsers::FileType::detect_m_file_type(&content))
+    } else {
+        parsers::FileType::from_extension(ext)
+    } {
         Some(ft) => ft,
         None => {
             return Ok(ParsedFile {

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -314,6 +314,53 @@ pub fn strip_perl_pod(content: &str) -> String {
     result
 }
 
+/// Strip Matlab comments (% line and %{ ... %} block) while preserving line numbers.
+pub fn strip_matlab_comments(content: &str) -> String {
+    let mut result = String::with_capacity(content.len());
+    let mut in_block = false;
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if !in_block && trimmed == "%{" {
+            in_block = true;
+            result.push_str(&" ".repeat(line.len()));
+            result.push('\n');
+        } else if in_block && trimmed == "%}" {
+            in_block = false;
+            result.push_str(&" ".repeat(line.len()));
+            result.push('\n');
+        } else if in_block {
+            result.push_str(&" ".repeat(line.len()));
+            result.push('\n');
+        } else {
+            // Find % not inside a string
+            let mut in_single = false;
+            let bytes = line.as_bytes();
+            let mut found = None;
+            for (idx, &b) in bytes.iter().enumerate() {
+                if b == b'\'' {
+                    in_single = !in_single;
+                } else if b == b'%' && !in_single {
+                    found = Some(idx);
+                    break;
+                }
+            }
+            if let Some(idx) = found {
+                result.push_str(&line[..idx]);
+                for _ in idx..line.len() {
+                    result.push(' ');
+                }
+            } else {
+                result.push_str(line);
+            }
+            result.push('\n');
+        }
+    }
+    if !content.ends_with('\n') && result.ends_with('\n') {
+        result.pop();
+    }
+    result
+}
+
 /// Strip XML comments (<!-- ... -->) while preserving line numbers.
 pub fn strip_xml_comments(content: &str) -> String {
     let bytes = content.as_bytes();
@@ -382,6 +429,7 @@ pub enum FileType {
     Scala,
     Php,
     Lua,
+    Matlab,
     Elixir,
     Bash,
     Groovy,
@@ -423,6 +471,65 @@ impl FileType {
             _ => None,
         }
     }
+
+    /// Detect whether a `.m` file is Matlab or Objective-C by inspecting content.
+    /// Scans up to 50 lines accumulating evidence before deciding.
+    pub fn detect_m_file_type(content: &str) -> FileType {
+        let mut saw_percent_comment = false;
+
+        for line in content.lines().take(50) {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+
+            // % comments are Matlab-only (never valid ObjC at line start)
+            if trimmed.starts_with('%') {
+                saw_percent_comment = true;
+                continue;
+            }
+
+            // Strong ObjC markers — immediate return
+            if trimmed.starts_with("#import")
+                || trimmed.starts_with("#include")
+                || trimmed.starts_with("#pragma")
+                || trimmed.starts_with("@interface")
+                || trimmed.starts_with("@implementation")
+                || trimmed.starts_with("@protocol")
+                || trimmed.starts_with("@property")
+                || trimmed.starts_with("@synthesize")
+                || trimmed.starts_with("@dynamic")
+                || trimmed.starts_with("@end")
+            {
+                return FileType::ObjC;
+            }
+
+            // Strong Matlab markers — immediate return
+            // Use word boundaries: "function " not "functionality"
+            if trimmed.starts_with("classdef ")
+                || trimmed.starts_with("classdef(")
+                || trimmed == "classdef"
+                || trimmed.starts_with("function ")
+                || trimmed.starts_with("function[")
+                || trimmed == "function"
+            {
+                return FileType::Matlab;
+            }
+
+            // C-style comments → ObjC
+            if trimmed.starts_with("//") || trimmed.starts_with("/*") {
+                return FileType::ObjC;
+            }
+        }
+
+        // If % comments found but no strong markers → Matlab
+        if saw_percent_comment {
+            return FileType::Matlab;
+        }
+
+        // Default to ObjC (backward compatible)
+        FileType::ObjC
+    }
 }
 
 /// Check if file extension is supported for indexing
@@ -463,6 +570,8 @@ fn strip_comments(content: &str, file_type: FileType) -> String {
         // Hash comments
         FileType::Bash | FileType::R | FileType::Elixir => strip_hash_comments(content),
 
+        // Matlab: % line comments and %{ %} block comments
+        FileType::Matlab => strip_matlab_comments(content),
         // SQL: -- line comments and /* */ block comments (C-style)
         FileType::Sql => strip_c_comments(content, false),
 
@@ -842,5 +951,60 @@ mod tests {
         assert_eq!(FileType::from_extension("pm"), Some(FileType::Perl));
         assert_eq!(FileType::from_extension("txt"), None);
         assert_eq!(FileType::from_extension(""), None);
+    }
+
+    #[test]
+    fn test_detect_m_file_objc_import() {
+        let content = "#import <Foundation/Foundation.h>\n@interface Foo : NSObject\n@end\n";
+        assert_eq!(FileType::detect_m_file_type(content), FileType::ObjC);
+    }
+
+    #[test]
+    fn test_detect_m_file_objc_interface() {
+        let content = "@interface MyClass : NSObject\n@end\n";
+        assert_eq!(FileType::detect_m_file_type(content), FileType::ObjC);
+    }
+
+    #[test]
+    fn test_detect_m_file_objc_c_comment() {
+        let content = "// This is ObjC\n@implementation Foo\n@end\n";
+        assert_eq!(FileType::detect_m_file_type(content), FileType::ObjC);
+    }
+
+    #[test]
+    fn test_detect_m_file_matlab_function() {
+        let content = "function result = myFunc(x)\n    result = x + 1;\nend\n";
+        assert_eq!(FileType::detect_m_file_type(content), FileType::Matlab);
+    }
+
+    #[test]
+    fn test_detect_m_file_matlab_classdef() {
+        let content = "classdef MyClass < handle\n    properties\n        Value\n    end\nend\n";
+        assert_eq!(FileType::detect_m_file_type(content), FileType::Matlab);
+    }
+
+    #[test]
+    fn test_detect_m_file_matlab_percent_comment() {
+        // Matlab script with % comment followed by plain statement
+        let content = "% This is a Matlab script\nx = 5;\ny = x + 1;\n";
+        assert_eq!(FileType::detect_m_file_type(content), FileType::Matlab);
+    }
+
+    #[test]
+    fn test_detect_m_file_matlab_function_with_comments() {
+        let content = "% My function\n% Does stuff\nfunction y = helper(x)\n    y = x * 2;\nend\n";
+        assert_eq!(FileType::detect_m_file_type(content), FileType::Matlab);
+    }
+
+    #[test]
+    fn test_detect_m_file_empty() {
+        assert_eq!(FileType::detect_m_file_type(""), FileType::ObjC);
+    }
+
+    #[test]
+    fn test_detect_m_file_word_boundary() {
+        // "functionality" should NOT match "function"
+        let content = "% comment\nfunctionality = 5;\n";
+        assert_eq!(FileType::detect_m_file_type(content), FileType::Matlab);
     }
 }

--- a/src/parsers/treesitter/matlab.rs
+++ b/src/parsers/treesitter/matlab.rs
@@ -1,0 +1,261 @@
+//! Tree-sitter based Matlab parser
+
+use anyhow::Result;
+use tree_sitter::{Language, Query, QueryCursor, StreamingIterator};
+use std::sync::LazyLock;
+
+use crate::db::SymbolKind;
+use crate::parsers::ParsedSymbol;
+use super::{LanguageParser, parse_tree, node_text, node_line, line_text};
+
+static MATLAB_LANGUAGE: LazyLock<Language> = LazyLock::new(|| tree_sitter_matlab::LANGUAGE.into());
+
+static MATLAB_QUERY: LazyLock<Query> = LazyLock::new(|| {
+    Query::new(&MATLAB_LANGUAGE, include_str!("queries/matlab.scm"))
+        .expect("Failed to compile Matlab tree-sitter query")
+});
+
+pub static MATLAB_PARSER: MatlabParser = MatlabParser;
+
+pub struct MatlabParser;
+
+impl LanguageParser for MatlabParser {
+    fn parse_symbols(&self, content: &str) -> Result<Vec<ParsedSymbol>> {
+        let tree = parse_tree(content, &MATLAB_LANGUAGE)?;
+        let mut symbols = Vec::new();
+        let query = &*MATLAB_QUERY;
+        let mut cursor = QueryCursor::new();
+
+        let capture_names = query.capture_names();
+        let idx = |name: &str| -> Option<u32> {
+            capture_names.iter().position(|n| *n == name).map(|i| i as u32)
+        };
+
+        let idx_class_name = idx("class_name");
+        let idx_func_name = idx("func_name");
+        let idx_property_name = idx("property_name");
+        let idx_enum_name = idx("enum_name");
+        let idx_event_name = idx("event_name");
+
+        let mut matches = cursor.matches(query, tree.root_node(), content.as_bytes());
+
+        while let Some(m) = matches.next() {
+            for cap in m.captures {
+                let name = node_text(content, &cap.node);
+                let line = node_line(&cap.node);
+                let sig = line_text(content, line).trim().to_string();
+
+                if Some(cap.index) == idx_class_name {
+                    // Extract superclasses from the class_definition node
+                    let class_node = cap.node.parent().unwrap();
+                    let parents = extract_superclasses(content, &class_node);
+                    symbols.push(ParsedSymbol {
+                        name: name.to_string(),
+                        kind: SymbolKind::Class,
+                        line,
+                        signature: sig,
+                        parents,
+                    });
+                } else if Some(cap.index) == idx_func_name {
+                    // Check if this function is inside a class (method) or standalone
+                    let parent_class = find_parent_class(content, &cap.node);
+                    let kind = SymbolKind::Function;
+                    let parents = if let Some(class_name) = parent_class {
+                        vec![(class_name, "member_of".to_string())]
+                    } else {
+                        vec![]
+                    };
+                    symbols.push(ParsedSymbol {
+                        name: name.to_string(),
+                        kind,
+                        line,
+                        signature: sig,
+                        parents,
+                    });
+                } else if Some(cap.index) == idx_property_name {
+                    let parent_class = find_parent_class(content, &cap.node);
+                    let parents = if let Some(class_name) = parent_class {
+                        vec![(class_name, "member_of".to_string())]
+                    } else {
+                        vec![]
+                    };
+                    symbols.push(ParsedSymbol {
+                        name: name.to_string(),
+                        kind: SymbolKind::Property,
+                        line,
+                        signature: sig,
+                        parents,
+                    });
+                } else if Some(cap.index) == idx_enum_name {
+                    let parent_class = find_parent_class(content, &cap.node);
+                    let parents = if let Some(class_name) = parent_class {
+                        vec![(class_name, "member_of".to_string())]
+                    } else {
+                        vec![]
+                    };
+                    symbols.push(ParsedSymbol {
+                        name: name.to_string(),
+                        kind: SymbolKind::Constant,
+                        line,
+                        signature: sig,
+                        parents,
+                    });
+                } else if Some(cap.index) == idx_event_name {
+                    let parent_class = find_parent_class(content, &cap.node);
+                    let parents = if let Some(class_name) = parent_class {
+                        vec![(class_name, "member_of".to_string())]
+                    } else {
+                        vec![]
+                    };
+                    symbols.push(ParsedSymbol {
+                        name: name.to_string(),
+                        kind: SymbolKind::Property,
+                        line,
+                        signature: sig,
+                        parents,
+                    });
+                }
+            }
+        }
+
+        Ok(symbols)
+    }
+}
+
+/// Walk up the tree to find a parent class_definition and return its name
+fn find_parent_class(content: &str, node: &tree_sitter::Node) -> Option<String> {
+    let mut current = node.parent();
+    while let Some(n) = current {
+        if n.kind() == "class_definition" {
+            // Get the name child
+            let mut cursor = n.walk();
+            for child in n.children(&mut cursor) {
+                if child.kind() == "identifier" {
+                    return Some(node_text(content, &child).to_string());
+                }
+            }
+        }
+        current = n.parent();
+    }
+    None
+}
+
+/// Extract superclass names from a class_definition node
+fn extract_superclasses(content: &str, class_node: &tree_sitter::Node) -> Vec<(String, String)> {
+    let mut parents = Vec::new();
+    let mut cursor = class_node.walk();
+    for child in class_node.children(&mut cursor) {
+        if child.kind() == "superclasses" {
+            let mut sc_cursor = child.walk();
+            for sc_child in child.children(&mut sc_cursor) {
+                if sc_child.kind() == "identifier" || sc_child.kind() == "property_name" {
+                    let name = node_text(content, &sc_child);
+                    parents.push((name.to_string(), "extends".to_string()));
+                }
+            }
+        }
+    }
+    parents
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_function() {
+        let content = "function result = myFunction(x, y)\n    result = x + y;\nend\n";
+        let symbols = MATLAB_PARSER.parse_symbols(content).unwrap();
+        assert!(symbols.iter().any(|s| s.name == "myFunction" && s.kind == SymbolKind::Function));
+    }
+
+    #[test]
+    fn test_parse_class() {
+        let content = r#"classdef MyClass
+    properties
+        Value
+    end
+    methods
+        function obj = MyClass(val)
+            obj.Value = val;
+        end
+    end
+end
+"#;
+        let symbols = MATLAB_PARSER.parse_symbols(content).unwrap();
+        assert!(symbols.iter().any(|s| s.name == "MyClass" && s.kind == SymbolKind::Class));
+        assert!(symbols.iter().any(|s| s.name == "Value" && s.kind == SymbolKind::Property));
+        assert!(symbols.iter().any(|s| s.name == "MyClass" && s.kind == SymbolKind::Function));
+    }
+
+    #[test]
+    fn test_parse_class_with_superclass() {
+        let content = r#"classdef Vehicle < handle
+    properties
+        Make
+        Model
+    end
+    methods
+        function obj = Vehicle(make, model)
+            obj.Make = make;
+            obj.Model = model;
+        end
+    end
+end
+"#;
+        let symbols = MATLAB_PARSER.parse_symbols(content).unwrap();
+        let class = symbols.iter().find(|s| s.name == "Vehicle" && s.kind == SymbolKind::Class).unwrap();
+        assert!(class.parents.iter().any(|(name, kind)| name == "handle" && kind == "extends"));
+    }
+
+    #[test]
+    fn test_parse_enumeration() {
+        let content = r#"classdef Color
+    enumeration
+        Red, Green, Blue
+    end
+end
+"#;
+        let symbols = MATLAB_PARSER.parse_symbols(content).unwrap();
+        assert!(symbols.iter().any(|s| s.name == "Red" && s.kind == SymbolKind::Constant));
+        assert!(symbols.iter().any(|s| s.name == "Green" && s.kind == SymbolKind::Constant));
+        assert!(symbols.iter().any(|s| s.name == "Blue" && s.kind == SymbolKind::Constant));
+    }
+
+    #[test]
+    fn test_parse_events() {
+        let content = r#"classdef Button < handle
+    events
+        ButtonPressed
+        ButtonReleased
+    end
+end
+"#;
+        let symbols = MATLAB_PARSER.parse_symbols(content).unwrap();
+        assert!(symbols.iter().any(|s| s.name == "ButtonPressed" && s.kind == SymbolKind::Property));
+        assert!(symbols.iter().any(|s| s.name == "ButtonReleased" && s.kind == SymbolKind::Property));
+    }
+
+    #[test]
+    fn test_method_parent_class() {
+        let content = r#"classdef Calculator
+    methods
+        function result = add(obj, a, b)
+            result = a + b;
+        end
+    end
+end
+"#;
+        let symbols = MATLAB_PARSER.parse_symbols(content).unwrap();
+        let method = symbols.iter().find(|s| s.name == "add" && s.kind == SymbolKind::Function).unwrap();
+        assert!(method.parents.iter().any(|(name, kind)| name == "Calculator" && kind == "member_of"));
+    }
+
+    #[test]
+    fn test_standalone_function() {
+        let content = "function y = helper(x)\n    y = x * 2;\nend\n";
+        let symbols = MATLAB_PARSER.parse_symbols(content).unwrap();
+        let func = symbols.iter().find(|s| s.name == "helper" && s.kind == SymbolKind::Function).unwrap();
+        assert!(func.parents.is_empty());
+    }
+}

--- a/src/parsers/treesitter/mod.rs
+++ b/src/parsers/treesitter/mod.rs
@@ -14,6 +14,7 @@ pub mod groovy;
 pub mod java;
 pub mod kotlin;
 pub mod lua;
+pub mod matlab;
 pub mod objc;
 pub mod php;
 pub mod proto;
@@ -57,6 +58,7 @@ pub fn get_treesitter_parser(file_type: FileType) -> Option<&'static dyn Languag
         FileType::Java => Some(&java::JAVA_PARSER),
         FileType::Kotlin => Some(&kotlin::KOTLIN_PARSER),
         FileType::Lua => Some(&lua::LUA_PARSER),
+        FileType::Matlab => Some(&matlab::MATLAB_PARSER),
         FileType::ObjC => Some(&objc::OBJC_PARSER),
         FileType::Php => Some(&php::PHP_PARSER),
         FileType::Proto => Some(&proto::PROTO_PARSER),

--- a/src/parsers/treesitter/queries/matlab.scm
+++ b/src/parsers/treesitter/queries/matlab.scm
@@ -1,0 +1,23 @@
+; Class definition
+(class_definition
+  name: (identifier) @class_name)
+
+; Function definition (identifier form)
+(function_definition
+  name: (identifier) @func_name)
+
+; Function definition (property_name form, e.g., set.Prop / get.Prop)
+(function_definition
+  name: (property_name) @func_name)
+
+; Properties block with property declarations
+(property
+  name: (identifier) @property_name)
+
+; Enumeration members
+(enum
+  (identifier) @enum_name)
+
+; Events
+(events
+  (identifier) @event_name)

--- a/tests/memory_tests.rs
+++ b/tests/memory_tests.rs
@@ -116,9 +116,9 @@ impl MemStats {
 use ast_index::db;
 use ast_index::parsers::treesitter::{
     cpp::CPP_PARSER, dart::DART_PARSER, go::GO_PARSER, java::JAVA_PARSER,
-    kotlin::KOTLIN_PARSER, python::PYTHON_PARSER, ruby::RUBY_PARSER,
-    rust_lang::RUST_PARSER, scala::SCALA_PARSER, swift::SWIFT_PARSER,
-    typescript::TYPESCRIPT_PARSER, LanguageParser,
+    kotlin::KOTLIN_PARSER, matlab::MATLAB_PARSER, python::PYTHON_PARSER,
+    ruby::RUBY_PARSER, rust_lang::RUST_PARSER, scala::SCALA_PARSER,
+    swift::SWIFT_PARSER, typescript::TYPESCRIPT_PARSER, LanguageParser,
 };
 use ast_index::parsers::{parse_file_symbols, FileType};
 use rusqlite::{params, Connection};
@@ -536,6 +536,7 @@ parser_memory_test!(parser_memory_cpp, CPP_PARSER, CPP_SNIPPET, PARSER_SMALL_BUD
 parser_memory_test!(parser_memory_ruby, RUBY_PARSER, RUBY_SNIPPET, PARSER_SMALL_BUDGET);
 parser_memory_test!(parser_memory_dart, DART_PARSER, DART_SNIPPET, PARSER_SMALL_BUDGET);
 parser_memory_test!(parser_memory_scala, SCALA_PARSER, SCALA_SNIPPET, PARSER_SMALL_BUDGET);
+parser_memory_test!(parser_memory_matlab, MATLAB_PARSER, MATLAB_CODE, PARSER_SMALL_BUDGET);
 
 // Large files
 parser_memory_test!(parser_memory_kotlin_large, KOTLIN_PARSER, LARGE_KOTLIN_CODE, PARSER_LARGE_BUDGET);
@@ -692,6 +693,29 @@ class InMemoryCatalog extends CatalogRepository {
   override def findByCategory(cat: String): List[Product] = store.values.filter(_.category == cat).toList
   override def save(p: Product): Either[String, Product] = { store += (p.id -> p); Right(p) }
 }
+"#;
+
+const MATLAB_CODE: &str = r#"
+classdef Vehicle < handle
+    properties
+        Make
+        Model
+        Year
+    end
+    methods
+        function obj = Vehicle(make, model, year)
+            obj.Make = make;
+            obj.Model = model;
+            obj.Year = year;
+        end
+        function display(obj)
+            fprintf('%s %s %d\n', obj.Make, obj.Model, obj.Year);
+        end
+    end
+    enumeration
+        Car, Truck, SUV
+    end
+end
 "#;
 
 // ===========================================================================


### PR DESCRIPTION
## Summary
- Add Matlab/Octave language support as the 28th supported language
- Includes tree-sitter parser with queries for functions, classes, properties, and methods
- Adds Matlab-specific commands documentation and file extension mappings
- Includes test coverage for Matlab parsing

## Tests
All 20 tests pass, including `parser_memory_matlab`:
```
test result: ok. 20 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)