### PR TITLE
Fix update wiping files under extra roots

### DIFF
--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -8,6 +8,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::SystemTime;
 
+use crate::db;
 use crate::parsers::{self, ParsedRef, ParsedSymbol};
 
 /// Sorted module lookup for efficient longest-prefix matching.
@@ -953,7 +954,13 @@ fn write_batch_to_db(conn: &mut Connection, batch: Vec<ParsedFile>, total_count:
     Ok(())
 }
 
-/// Incremental update: only re-index changed/new files, delete removed files
+/// Incremental update: only re-index changed/new files, delete removed files.
+///
+/// Walks the primary root AND every extra_root registered in metadata. Each
+/// root's files are stored with paths relative to that root (matching how
+/// `rebuild` indexed them), so reconciliation against the DB works correctly
+/// for extra_roots — without this, extra-root files were seen as "missing"
+/// during the primary walk and deleted on every `update`.
 pub fn update_directory_incremental(conn: &mut Connection, root: &Path, progress: bool) -> Result<(usize, usize, usize)> {
     use ignore::WalkBuilder;
     use std::collections::HashMap;
@@ -976,64 +983,80 @@ pub fn update_directory_incremental(conn: &mut Connection, root: &Path, progress
         eprintln!("Loaded {} files from index", existing_files.len());
     }
 
-    // 2. Walk filesystem and collect files to update
-    let is_git = has_git_repo(root);
-    let arc_root = find_arc_root(root);
-    let mut builder = WalkBuilder::new(root);
-    builder
-        .hidden(true)
-        .git_ignore(is_git)
-        .filter_entry(|entry| !is_excluded_dir(entry));
-    if let Some(ref arc) = arc_root {
-        builder.add_custom_ignore_filename(".gitignore");
-        builder.add_custom_ignore_filename(".arcignore");
-        let root_gitignore = arc.join(".gitignore");
-        if root_gitignore.exists() {
-            builder.add_ignore(root_gitignore);
+    // 2. Build the list of roots to walk: primary + any extra_roots from the
+    //    DB metadata. Extra roots that no longer exist on disk are skipped so
+    //    their prior entries are treated as deleted.
+    let mut roots: Vec<PathBuf> = vec![root.to_path_buf()];
+    if let Ok(extra) = db::get_extra_roots(conn) {
+        for e in extra {
+            let p = PathBuf::from(&e);
+            if p.exists() {
+                roots.push(p);
+            } else if progress {
+                eprintln!("Skipping missing extra root: {}", e);
+            }
         }
     }
-    let walker = builder.build();
 
-    let current_files: Vec<PathBuf> = walker
-        .filter_map(|e| e.ok())
-        .filter(|e| {
-            e.path()
+    // 3. Walk each root and categorize its files. Paths are relative to the
+    //    root they were discovered under, matching `index_directory_with_config`'s
+    //    storage scheme used during rebuild.
+    let mut files_to_parse: Vec<(PathBuf, PathBuf)> = Vec::new(); // (root, file_path)
+    let mut current_paths: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    for walk_root in &roots {
+        let is_git = has_git_repo(walk_root);
+        let arc_root = find_arc_root(walk_root);
+        let mut builder = WalkBuilder::new(walk_root);
+        builder
+            .hidden(true)
+            .git_ignore(is_git)
+            .filter_entry(|entry| !is_excluded_dir(entry));
+        if let Some(ref arc) = arc_root {
+            builder.add_custom_ignore_filename(".gitignore");
+            builder.add_custom_ignore_filename(".arcignore");
+            let root_gitignore = arc.join(".gitignore");
+            if root_gitignore.exists() {
+                builder.add_ignore(root_gitignore);
+            }
+        }
+        let walker = builder.build();
+
+        for entry in walker.filter_map(|e| e.ok()) {
+            let is_supported = entry
+                .path()
                 .extension()
                 .and_then(|ext| ext.to_str())
                 .map(parsers::is_supported_extension)
-                .unwrap_or(false)
-        })
-        .map(|e| e.path().to_path_buf())
-        .collect();
+                .unwrap_or(false);
+            if !is_supported {
+                continue;
+            }
 
-    // 3. Categorize files: new, changed, unchanged
-    let mut files_to_parse: Vec<PathBuf> = Vec::new();
-    let mut current_paths: std::collections::HashSet<String> = std::collections::HashSet::new();
+            let file_path = entry.path().to_path_buf();
+            let rel_path = file_path
+                .strip_prefix(walk_root)
+                .unwrap_or(&file_path)
+                .to_string_lossy()
+                .to_string();
 
-    for file_path in current_files {
-        let rel_path = file_path
-            .strip_prefix(root)
-            .unwrap_or(&file_path)
-            .to_string_lossy()
-            .to_string();
+            let file_mtime = fs::metadata(&file_path)
+                .and_then(|m| m.modified())
+                .ok()
+                .and_then(|t| t.duration_since(std::time::SystemTime::UNIX_EPOCH).ok())
+                .map(|d| d.as_secs() as i64)
+                .unwrap_or(0);
 
-        let file_mtime = fs::metadata(&file_path)
-            .and_then(|m| m.modified())
-            .ok()
-            .and_then(|t| t.duration_since(std::time::SystemTime::UNIX_EPOCH).ok())
-            .map(|d| d.as_secs() as i64)
-            .unwrap_or(0);
+            let need_parse = match existing_files.get(&rel_path) {
+                Some((_, db_mtime)) => file_mtime > *db_mtime,
+                None => true,
+            };
 
-        let need_parse = if let Some((_, db_mtime)) = existing_files.get(&rel_path) {
-            file_mtime > *db_mtime
-        } else {
-            true
-        };
-
-        if need_parse {
-            files_to_parse.push(file_path);
+            if need_parse {
+                files_to_parse.push((walk_root.clone(), file_path));
+            }
+            current_paths.insert(rel_path);
         }
-        current_paths.insert(rel_path);
     }
 
     // 4. Find deleted files
@@ -1067,13 +1090,12 @@ pub fn update_directory_incremental(conn: &mut Connection, root: &Path, progress
     let updated_count = if !files_to_parse.is_empty() {
         let total_files = files_to_parse.len();
         let parsed_count = Arc::new(AtomicUsize::new(0));
-        let root_clone = root.to_path_buf();
         let parsed_count_clone = parsed_count.clone();
 
         let parsed_files: Vec<ParsedFile> = files_to_parse
             .par_iter()
-            .filter_map(|path| {
-                let result = parse_file(&root_clone, path).ok();
+            .filter_map(|(file_root, path)| {
+                let result = parse_file(file_root, path).ok();
                 let c = parsed_count_clone.fetch_add(1, Ordering::Relaxed) + 1;
                 if progress && c % 500 == 0 {
                     eprintln!("Parsed {} / {} changed files...", c, total_files);

--- a/tests/update_extra_roots_tests.rs
+++ b/tests/update_extra_roots_tests.rs
@@ -1,0 +1,187 @@
+//! Regression tests for `update_directory_incremental` honouring extra roots.
+//!
+//! Bug: previously, `update` only walked the primary root. Files in any extra
+//! root (registered via `db::add_extra_root` and indexed by `rebuild`) were
+//! seen as missing from the walk and deleted from the DB on every `update` —
+//! wiping all third-party / external sources between sessions.
+//!
+//! These tests cover the round-trip: rebuild populates both roots, update
+//! preserves them, and update still correctly detects real deletions and new
+//! files in either root.
+
+use std::fs;
+use std::path::Path;
+
+use ast_index::{db, indexer};
+use rusqlite::Connection;
+use tempfile::TempDir;
+
+/// Initialise an on-disk DB at the conventional location for `project_root`.
+/// We use `open_db` (not in-memory) so subsequent calls reopen the same DB,
+/// matching how the CLI commands behave.
+fn open_fresh_db(project_root: &Path) -> Connection {
+    if db::db_exists(project_root) {
+        db::delete_db(project_root).unwrap();
+    }
+    let conn = db::open_db(project_root).unwrap();
+    db::init_db(&conn).unwrap();
+    // Record the primary root in metadata, mirroring `cmd_rebuild`.
+    conn.execute(
+        "INSERT OR REPLACE INTO metadata (key, value) VALUES ('project_root', ?1)",
+        rusqlite::params![project_root.to_string_lossy().to_string()],
+    )
+    .unwrap();
+    conn
+}
+
+fn write_file(path: &Path, contents: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, contents).unwrap();
+}
+
+fn count_files(conn: &Connection) -> i64 {
+    conn.query_row("SELECT COUNT(*) FROM files", [], |row| row.get(0))
+        .unwrap()
+}
+
+fn has_file(conn: &Connection, rel_path: &str) -> bool {
+    let count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM files WHERE path = ?1",
+            rusqlite::params![rel_path],
+            |row| row.get(0),
+        )
+        .unwrap();
+    count > 0
+}
+
+/// Rebuild the index for the given primary + extra roots, mimicking the
+/// relevant slice of `cmd_rebuild`.
+fn rebuild(conn: &mut Connection, primary: &Path, extras: &[&Path]) {
+    for extra in extras {
+        db::add_extra_root(conn, &extra.to_string_lossy()).unwrap();
+    }
+    indexer::index_directory_with_config(conn, primary, false, false, None, None).unwrap();
+    for extra in extras {
+        indexer::index_directory_with_config(conn, extra, false, false, None, None).unwrap();
+    }
+}
+
+const SWIFT_SAMPLE: &str = "import Foundation\n\nclass Sample {}\n";
+
+/// THE regression test: after rebuild populates both roots, a subsequent
+/// `update` with no filesystem changes must not touch the file count and
+/// must not report any deletions.
+#[test]
+fn update_preserves_extra_root_files() {
+    let primary_dir = TempDir::new().unwrap();
+    let extra_dir = TempDir::new().unwrap();
+    let primary = primary_dir.path();
+    let extra = extra_dir.path();
+
+    write_file(&primary.join("App.swift"), SWIFT_SAMPLE);
+    write_file(&extra.join("pkgs/Lib.swift"), SWIFT_SAMPLE);
+
+    let mut conn = open_fresh_db(primary);
+    rebuild(&mut conn, primary, &[extra]);
+
+    let files_before = count_files(&conn);
+    assert_eq!(files_before, 2, "expected both primary and extra files indexed");
+    assert!(has_file(&conn, "App.swift"));
+    assert!(has_file(&conn, "pkgs/Lib.swift"));
+
+    let (updated, changed, deleted) =
+        indexer::update_directory_incremental(&mut conn, primary, false).unwrap();
+
+    assert_eq!(deleted, 0, "update must not delete extra-root files");
+    assert_eq!(updated, 0);
+    assert_eq!(changed, 0);
+    assert_eq!(count_files(&conn), files_before);
+    assert!(has_file(&conn, "pkgs/Lib.swift"), "extra-root file disappeared after update");
+}
+
+/// Update must still detect a genuine deletion under an extra root.
+#[test]
+fn update_detects_deleted_extra_root_file() {
+    let primary_dir = TempDir::new().unwrap();
+    let extra_dir = TempDir::new().unwrap();
+    let primary = primary_dir.path();
+    let extra = extra_dir.path();
+
+    write_file(&primary.join("App.swift"), SWIFT_SAMPLE);
+    write_file(&extra.join("a/Keep.swift"), SWIFT_SAMPLE);
+    let drop_me = extra.join("a/Drop.swift");
+    write_file(&drop_me, SWIFT_SAMPLE);
+
+    let mut conn = open_fresh_db(primary);
+    rebuild(&mut conn, primary, &[extra]);
+    assert_eq!(count_files(&conn), 3);
+
+    fs::remove_file(&drop_me).unwrap();
+
+    let (_, _, deleted) =
+        indexer::update_directory_incremental(&mut conn, primary, false).unwrap();
+
+    assert_eq!(deleted, 1);
+    assert!(has_file(&conn, "App.swift"));
+    assert!(has_file(&conn, "a/Keep.swift"));
+    assert!(!has_file(&conn, "a/Drop.swift"));
+}
+
+/// New files appearing under either root between sessions must be indexed.
+#[test]
+fn update_indexes_new_files_in_both_roots() {
+    let primary_dir = TempDir::new().unwrap();
+    let extra_dir = TempDir::new().unwrap();
+    let primary = primary_dir.path();
+    let extra = extra_dir.path();
+
+    write_file(&primary.join("App.swift"), SWIFT_SAMPLE);
+    write_file(&extra.join("Lib.swift"), SWIFT_SAMPLE);
+
+    let mut conn = open_fresh_db(primary);
+    rebuild(&mut conn, primary, &[extra]);
+    assert_eq!(count_files(&conn), 2);
+
+    write_file(&primary.join("New.swift"), SWIFT_SAMPLE);
+    write_file(&extra.join("pkgs/NewLib.swift"), SWIFT_SAMPLE);
+
+    let (updated, _, deleted) =
+        indexer::update_directory_incremental(&mut conn, primary, false).unwrap();
+
+    assert_eq!(deleted, 0);
+    assert_eq!(updated, 2, "both new files should be parsed and stored");
+    assert!(has_file(&conn, "New.swift"));
+    assert!(has_file(&conn, "pkgs/NewLib.swift"));
+}
+
+/// If an extra root has been removed from disk entirely (e.g. user wiped a
+/// build cache), update must skip the missing root and report its prior
+/// entries as deleted, without crashing.
+#[test]
+fn update_skips_missing_extra_root() {
+    let primary_dir = TempDir::new().unwrap();
+    let extra_dir = TempDir::new().unwrap();
+    let primary = primary_dir.path();
+    let extra = extra_dir.path().to_path_buf();
+
+    write_file(&primary.join("App.swift"), SWIFT_SAMPLE);
+    write_file(&extra.join("Lib.swift"), SWIFT_SAMPLE);
+
+    let mut conn = open_fresh_db(primary);
+    rebuild(&mut conn, primary, &[&extra]);
+    assert_eq!(count_files(&conn), 2);
+
+    // Drop the extra root entirely.
+    drop(extra_dir);
+    assert!(!extra.exists());
+
+    let (_, _, deleted) =
+        indexer::update_directory_incremental(&mut conn, primary, false).unwrap();
+
+    assert_eq!(deleted, 1, "files under the missing extra root should be marked deleted");
+    assert!(has_file(&conn, "App.swift"));
+    assert!(!has_file(&conn, "Lib.swift"));
+}


### PR DESCRIPTION
## Summary

`update_directory_incremental` walked only the primary root when computing the "current files" set, so every file under an `extra_root` (added via `add-root`, indexed by `rebuild`) was marked deleted on each `update` — wiping extra roots between sessions.

- Walk primary + every `extra_root` from metadata, computing paths relative to the root each file was discovered under (matches `index_directory_with_config`'s storage scheme).
- Reconcile against the union of all walked paths, so `deleted_paths` only contains genuinely missing entries.
- Missing extra roots are skipped (prior entries correctly age out as deleted) instead of causing the walk to fail.

Reproducer on a real project (workspace + SPM extra root, 111k files):

| | before | after |
|---|---|---|
| `update` deleted count | 85862 | **0** |
| file count after `update` | 25180 | **111042** |

## Test plan

- [x] `cargo test --release` — 596 tests pass (existing + 4 new)
- [x] `tests/update_extra_roots_tests.rs` covers: no-op round trip, real deletion in extra root, new files in either root, vanished extra root
- [x] Manually re-verified on the reproducer project: repeated `update` runs keep extra-root files intact; real deletions and additions are still detected