### PR TITLE
Drop noisy output that wastes agent context

### DIFF
--- a/src/commands/analysis.rs
+++ b/src/commands/analysis.rs
@@ -3,7 +3,6 @@
 //! - unused-symbols: Find potentially unused public symbols
 
 use std::path::Path;
-use std::time::Instant;
 
 use anyhow::Result;
 use colored::Colorize;
@@ -19,8 +18,6 @@ pub fn cmd_unused_symbols(
     limit: usize,
     format: &str,
 ) -> Result<()> {
-    let start = Instant::now();
-
     if !db::db_exists(root) {
         println!(
             "{}",
@@ -168,9 +165,5 @@ pub fn cmd_unused_symbols(
         println!("  No unused symbols found.");
     }
 
-    eprintln!(
-        "\n{}",
-        format!("Time: {:?}", start.elapsed()).dimmed()
-    );
     Ok(())
 }

--- a/src/commands/android.rs
+++ b/src/commands/android.rs
@@ -6,7 +6,6 @@
 
 use std::collections::HashMap;
 use std::path::Path;
-use std::time::Instant;
 
 use anyhow::Result;
 use colored::Colorize;
@@ -16,8 +15,6 @@ use crate::db;
 
 /// Find XML usages of a class (layouts, views)
 pub fn cmd_xml_usages(root: &Path, class_name: &str, module_filter: Option<&str>) -> Result<()> {
-    let start = Instant::now();
-
     if !db::db_exists(root) {
         println!("{}", "Index not found. Run 'ast-index rebuild' first.".red());
         return Ok(());
@@ -85,7 +82,6 @@ pub fn cmd_xml_usages(root: &Path, class_name: &str, module_filter: Option<&str>
         println!("  No XML usages found.");
     }
 
-    eprintln!("\n{}", format!("Time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }
 
@@ -97,8 +93,6 @@ pub fn cmd_resource_usages(
     type_filter: Option<&str>,
     show_unused: bool,
 ) -> Result<()> {
-    let start = Instant::now();
-
     if !db::db_exists(root) {
         println!("{}", "Index not found. Run 'ast-index rebuild' first.".red());
         return Ok(());
@@ -236,7 +230,6 @@ pub fn cmd_resource_usages(
         }
     }
 
-    eprintln!("\n{}", format!("Time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }
 

--- a/src/commands/files.rs
+++ b/src/commands/files.rs
@@ -8,7 +8,6 @@
 //! - changed: Show changed symbols in git diff
 
 use std::path::{Path, PathBuf};
-use std::time::Instant;
 
 use anyhow::Result;
 use colored::Colorize;
@@ -36,8 +35,6 @@ fn outline_via_treesitter(content: &str, file_type: crate::parsers::FileType, sk
 
 /// Find files by pattern
 pub fn cmd_file(root: &Path, pattern: &str, exact: bool, limit: usize) -> Result<()> {
-    let start = Instant::now();
-
     if !db::db_exists(root) {
         println!(
             "{}",
@@ -61,14 +58,11 @@ pub fn cmd_file(root: &Path, pattern: &str, exact: bool, limit: usize) -> Result
         println!("  No files found.");
     }
 
-    eprintln!("\n{}", format!("Time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }
 
 /// Show file symbols outline
 pub fn cmd_outline(root: &Path, file: &str) -> Result<()> {
-    let start = Instant::now();
-
     // Find the file
     let file_path = if file.starts_with('/') {
         PathBuf::from(file)
@@ -151,14 +145,11 @@ pub fn cmd_outline(root: &Path, file: &str) -> Result<()> {
         println!("  No symbols found.");
     }
 
-    eprintln!("\n{}", format!("Time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }
 
 /// Show file imports
 pub fn cmd_imports(root: &Path, file: &str) -> Result<()> {
-    let start = Instant::now();
-
     let file_path = if file.starts_with('/') {
         PathBuf::from(file)
     } else {
@@ -262,14 +253,11 @@ pub fn cmd_imports(root: &Path, file: &str) -> Result<()> {
         println!("\n  Total: {} imports", imports.len());
     }
 
-    eprintln!("\n{}", format!("Time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }
 
 /// Show module public API
 pub fn cmd_api(root: &Path, module_path: &str, limit: usize) -> Result<()> {
-    let start = Instant::now();
-
     let mut module_dir = root.join(module_path);
 
     // If path not found, try converting dots to slashes (module name → path)
@@ -332,7 +320,6 @@ pub fn cmd_api(root: &Path, module_path: &str, limit: usize) -> Result<()> {
         println!("  No public API found.");
     }
 
-    eprintln!("\n{}", format!("Time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }
 
@@ -426,8 +413,6 @@ fn normalize_base_for_vcs(vcs: &str, base: &str) -> String {
 
 /// Show changed symbols in git/arc diff
 pub fn cmd_changed(root: &Path, base: &str) -> Result<()> {
-    let start = Instant::now();
-
     let vcs = detect_vcs(root);
     let base = normalize_base_for_vcs(vcs, base);
 
@@ -500,6 +485,5 @@ pub fn cmd_changed(root: &Path, base: &str) -> Result<()> {
         }
     }
 
-    eprintln!("\n{}", format!("Time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }

--- a/src/commands/grep.rs
+++ b/src/commands/grep.rs
@@ -17,7 +17,6 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::time::Instant;
 
 use anyhow::Result;
 use colored::Colorize;
@@ -103,7 +102,6 @@ fn build_def_skip_pattern(function_name: &str) -> Regex {
 
 /// Find TODO/FIXME/HACK comments
 pub fn cmd_todo(root: &Path, pattern: &str, limit: usize) -> Result<()> {
-    let start = Instant::now();
     let search_pattern = format!(r"//.*({pattern})|#.*({pattern})");
 
     let mut todos: HashMap<String, Vec<(String, usize, String)>> = HashMap::new();
@@ -150,13 +148,11 @@ pub fn cmd_todo(root: &Path, pattern: &str, limit: usize) -> Result<()> {
         }
     }
 
-    eprintln!("\n{}", format!("Time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }
 
 /// Find function callers
 pub fn cmd_callers(root: &Path, function_name: &str, limit: usize) -> Result<()> {
-    let start = Instant::now();
     let pattern = build_caller_pattern(function_name);
     let def_pattern = build_def_skip_pattern(function_name);
 
@@ -183,14 +179,11 @@ pub fn cmd_callers(root: &Path, function_name: &str, limit: usize) -> Result<()>
         }
     }
 
-    eprintln!("\n{}", format!("Time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }
 
 /// Show call hierarchy (callers tree) for a function
 pub fn cmd_call_tree(root: &Path, function_name: &str, max_depth: usize, limit_per_level: usize) -> Result<()> {
-    let start = Instant::now();
-
     println!("{}", format!("Call tree for '{}':", function_name).bold());
     println!("  {}", function_name.cyan());
 
@@ -199,7 +192,6 @@ pub fn cmd_call_tree(root: &Path, function_name: &str, max_depth: usize, limit_p
 
     build_call_tree(root, function_name, 1, max_depth, limit_per_level, &mut visited)?;
 
-    eprintln!("\n{}", format!("Time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }
 
@@ -313,8 +305,6 @@ fn find_containing_function(lines: &[&str], target_line: usize, func_def_re: &Re
 
 /// Find Dagger @Provides/@Binds for a type
 pub fn cmd_provides(root: &Path, type_name: &str, limit: usize) -> Result<()> {
-    let start = Instant::now();
-
     let mut results: Vec<(String, usize, String)> = vec![];
 
     // Walk files and search with context
@@ -393,13 +383,11 @@ pub fn cmd_provides(root: &Path, type_name: &str, limit: usize) -> Result<()> {
         println!("    {}", truncated);
     }
 
-    eprintln!("\n{}", format!("Time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }
 
 /// Find suspend functions
 pub fn cmd_suspend(root: &Path, query: Option<&str>, limit: usize) -> Result<()> {
-    let start = Instant::now();
     let pattern = r"suspend\s+fun\s+\w+";
     let func_regex = Regex::new(r"suspend\s+fun\s+(\w+)")?;
 
@@ -427,13 +415,11 @@ pub fn cmd_suspend(root: &Path, query: Option<&str>, limit: usize) -> Result<()>
         println!("  {}: {}:{}", func_name.cyan(), path, line_num);
     }
 
-    eprintln!("\n{}", format!("Time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }
 
 /// Find @Composable functions
 pub fn cmd_composables(root: &Path, query: Option<&str>, limit: usize) -> Result<()> {
-    let start = Instant::now();
     let func_regex = Regex::new(r"fun\s+(\w+)\s*\(")?;
 
     // Phase 1: find all .kt files containing @Composable
@@ -492,13 +478,11 @@ pub fn cmd_composables(root: &Path, query: Option<&str>, limit: usize) -> Result
         println!("  {}: {}:{}", func_name.cyan(), path, line_num);
     }
 
-    eprintln!("\n{}", format!("Time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }
 
 /// Find @Deprecated annotations
 pub fn cmd_deprecated(root: &Path, query: Option<&str>, limit: usize) -> Result<()> {
-    let start = Instant::now();
     // Kotlin/Java/C#: @Deprecated/@Obsolete, Swift: @available(*, deprecated)
     // Python: @deprecated, Perl: DEPRECATED, Rust: #[deprecated], Go: // Deprecated:
     // JS/TS: @deprecated (JSDoc), PHP: @deprecated (PHPDoc), C++: [[deprecated]]
@@ -525,13 +509,11 @@ pub fn cmd_deprecated(root: &Path, query: Option<&str>, limit: usize) -> Result<
         println!("    {}", content);
     }
 
-    eprintln!("\n{}", format!("Time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }
 
 /// Find @Suppress annotations
 pub fn cmd_suppress(root: &Path, query: Option<&str>, limit: usize) -> Result<()> {
-    let start = Instant::now();
     let pattern = r"@Suppress";
 
     let mut items: Vec<(String, usize, String)> = vec![];
@@ -555,13 +537,11 @@ pub fn cmd_suppress(root: &Path, query: Option<&str>, limit: usize) -> Result<()
         println!("    {}", content);
     }
 
-    eprintln!("\n{}", format!("Time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }
 
 /// Find @Inject/@Autowired points for a type
 pub fn cmd_inject(root: &Path, type_name: &str, limit: usize) -> Result<()> {
-    let start = Instant::now();
     let pattern = r"@Inject|@Autowired";
 
     let mut items: Vec<(String, usize, String)> = vec![];
@@ -590,13 +570,11 @@ pub fn cmd_inject(root: &Path, type_name: &str, limit: usize) -> Result<()> {
         println!("    {}", content);
     }
 
-    eprintln!("\n{}", format!("Time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }
 
 /// Find uses of specific annotation
 pub fn cmd_annotations(root: &Path, annotation: &str, limit: usize) -> Result<()> {
-    let start = Instant::now();
     // Normalize annotation (add @ if missing for Java/Kotlin/Swift/ObjC)
     // For Perl, attributes are like :lvalue, :method
     let search_annotation = if annotation.starts_with('@') || annotation.starts_with(':') {
@@ -621,13 +599,11 @@ pub fn cmd_annotations(root: &Path, annotation: &str, limit: usize) -> Result<()
         println!("    {}", content);
     }
 
-    eprintln!("\n{}", format!("Time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }
 
 /// Find deeplink definitions
 pub fn cmd_deeplinks(root: &Path, query: Option<&str>, limit: usize) -> Result<()> {
-    let start = Instant::now();
     // Search for specific deeplink patterns (NOT generic :// URLs)
     // Android: @DeepLink, DeepLinkHandler, @AppLink, NavDeepLink, intent-filter with android:scheme
     // iOS: openURL, application(_:open:, handleOpen, CFBundleURLSchemes, UniversalLink
@@ -654,13 +630,11 @@ pub fn cmd_deeplinks(root: &Path, query: Option<&str>, limit: usize) -> Result<(
         println!("    {}", content);
     }
 
-    eprintln!("\n{}", format!("Time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }
 
 /// Find extension functions/types
 pub fn cmd_extensions(root: &Path, receiver_type: &str, limit: usize) -> Result<()> {
-    let start = Instant::now();
     // Kotlin: fun ReceiverType.functionName
     // Swift: extension ReceiverType
     let kotlin_pattern = format!(r"fun\s+{}\.(\w+)", regex::escape(receiver_type));
@@ -694,13 +668,11 @@ pub fn cmd_extensions(root: &Path, receiver_type: &str, limit: usize) -> Result<
         }
     }
 
-    eprintln!("\n{}", format!("Time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }
 
 /// Find Flow declarations
 pub fn cmd_flows(root: &Path, query: Option<&str>, limit: usize) -> Result<()> {
-    let start = Instant::now();
     let pattern = r"(StateFlow|SharedFlow|MutableStateFlow|MutableSharedFlow|Flow<)";
     let flow_regex = Regex::new(r"(StateFlow|SharedFlow|MutableStateFlow|MutableSharedFlow|Flow)<")?;
 
@@ -729,13 +701,11 @@ pub fn cmd_flows(root: &Path, query: Option<&str>, limit: usize) -> Result<()> {
         println!("    {}", content);
     }
 
-    eprintln!("\n{}", format!("Time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }
 
 /// Find @Preview functions
 pub fn cmd_previews(root: &Path, query: Option<&str>, limit: usize) -> Result<()> {
-    let start = Instant::now();
     let func_regex = Regex::new(r"fun\s+(\w+)\s*\(")?;
 
     // Phase 1: find all .kt files containing @Preview
@@ -794,7 +764,6 @@ pub fn cmd_previews(root: &Path, query: Option<&str>, limit: usize) -> Result<()
         println!("  {}: {}:{}", func_name.cyan(), path, line_num);
     }
 
-    eprintln!("\n{}", format!("Time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }
 

--- a/src/commands/index.rs
+++ b/src/commands/index.rs
@@ -9,7 +9,6 @@
 //! - usages: Find symbol usages (indexed or grep-based)
 
 use std::path::Path;
-use std::time::Instant;
 
 use anyhow::Result;
 use colored::Colorize;
@@ -21,8 +20,6 @@ use super::{search_files, relative_path};
 
 /// Full-text search across files, symbols, and file contents
 pub fn cmd_search(root: &Path, query: &str, kind_filter: Option<&str>, limit: usize, format: &str, scope: &SearchScope, fuzzy: bool) -> Result<()> {
-    let total_start = Instant::now();
-
     if !db::db_exists(root) {
         println!(
             "{}",
@@ -48,11 +45,6 @@ pub fn cmd_search(root: &Path, query: &str, kind_filter: Option<&str>, limit: us
     let mut seen_refs = std::collections::HashSet::new();
     let mut seen_content = std::collections::HashSet::new();
 
-    let files_start = Instant::now();
-    let symbols_start; // declared below
-    let refs_start;
-    let content_start;
-
     // 1. Search in file paths (index)
     for term in &terms {
         let mut term_files = db::find_files(&conn, term, per_term_limit)?;
@@ -65,10 +57,8 @@ pub fn cmd_search(root: &Path, query: &str, kind_filter: Option<&str>, limit: us
             }
         }
     }
-    let files_time = files_start.elapsed();
 
     // 2. Search in symbols using FTS or fuzzy (index)
-    symbols_start = Instant::now();
     let fetch_limit = per_term_limit * if kind_filter.is_some() { 5 } else { 1 };
     for term in &terms {
         let raw = if fuzzy {
@@ -89,10 +79,8 @@ pub fn cmd_search(root: &Path, query: &str, kind_filter: Option<&str>, limit: us
         }
     }
     symbols.truncate(limit);
-    let symbols_time = symbols_start.elapsed();
 
     // 3. Search in references (imports and usages from index)
-    refs_start = Instant::now();
     for term in &terms {
         let term_refs = db::search_refs(&conn, term, per_term_limit)?;
         for (name, count) in term_refs {
@@ -101,10 +89,8 @@ pub fn cmd_search(root: &Path, query: &str, kind_filter: Option<&str>, limit: us
             }
         }
     }
-    let refs_time = refs_start.elapsed();
 
     // 4. Search in file contents (grep)
-    content_start = Instant::now();
     let pattern = if terms.len() > 1 {
         terms.iter().map(|t| regex::escape(t)).collect::<Vec<_>>().join("|")
     } else {
@@ -129,7 +115,6 @@ pub fn cmd_search(root: &Path, query: &str, kind_filter: Option<&str>, limit: us
             content_matches.push((rel_path, line_num, content));
         }
     })?;
-    let content_time = content_start.elapsed();
 
     if format == "json" {
         let result = serde_json::json!({
@@ -188,18 +173,11 @@ pub fn cmd_search(root: &Path, query: &str, kind_filter: Option<&str>, limit: us
         println!("  No results found.");
     }
 
-    // Timing breakdown
-    eprintln!("\n{}", format!(
-        "Time: {:?} (files: {:?}, symbols: {:?}, refs: {:?}, content: {:?})",
-        total_start.elapsed(), files_time, symbols_time, refs_time, content_time
-    ).dimmed());
     Ok(())
 }
 
 /// Find symbol by name or glob pattern
 pub fn cmd_symbol(root: &Path, name: Option<&str>, pattern: Option<&str>, kind: Option<&str>, limit: usize, format: &str, scope: &SearchScope, fuzzy: bool) -> Result<()> {
-    let start = Instant::now();
-
     if !db::db_exists(root) {
         println!(
             "{}",
@@ -250,14 +228,11 @@ pub fn cmd_symbol(root: &Path, name: Option<&str>, pattern: Option<&str>, kind: 
         println!("  No symbols found.");
     }
 
-    eprintln!("\n{}", format!("Time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }
 
 /// Find class by name or glob pattern (classes, interfaces, objects, enums)
 pub fn cmd_class(root: &Path, name: Option<&str>, pattern: Option<&str>, limit: usize, format: &str, scope: &SearchScope, fuzzy: bool) -> Result<()> {
-    let start = Instant::now();
-
     if !db::db_exists(root) {
         println!(
             "{}",
@@ -305,14 +280,11 @@ pub fn cmd_class(root: &Path, name: Option<&str>, pattern: Option<&str>, limit: 
         println!("  No classes found.");
     }
 
-    eprintln!("\n{}", format!("Time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }
 
 /// Find implementations of interface/class
 pub fn cmd_implementations(root: &Path, parent: &str, limit: usize, format: &str, scope: &SearchScope) -> Result<()> {
-    let start = Instant::now();
-
     if !db::db_exists(root) {
         println!(
             "{}",
@@ -342,14 +314,11 @@ pub fn cmd_implementations(root: &Path, parent: &str, limit: usize, format: &str
         println!("  No implementations found.");
     }
 
-    eprintln!("\n{}", format!("Time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }
 
 /// Show cross-references: definitions, imports, usages
 pub fn cmd_refs(root: &Path, symbol: &str, limit: usize, format: &str) -> Result<()> {
-    let start = Instant::now();
-
     if !db::db_exists(root) {
         println!(
             "{}",
@@ -405,14 +374,11 @@ pub fn cmd_refs(root: &Path, symbol: &str, limit: usize, format: &str) -> Result
         println!("  No references found.");
     }
 
-    eprintln!("\n{}", format!("Time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }
 
 /// Show class hierarchy (parents and children)
 pub fn cmd_hierarchy(root: &Path, name: &str, scope: &SearchScope) -> Result<()> {
-    let start = Instant::now();
-
     if !db::db_exists(root) {
         println!(
             "{}",
@@ -478,14 +444,11 @@ pub fn cmd_hierarchy(root: &Path, name: &str, scope: &SearchScope) -> Result<()>
         }
     }
 
-    eprintln!("\n{}", format!("Time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }
 
 /// Find symbol usages (indexed or grep-based)
 pub fn cmd_usages(root: &Path, symbol: &str, limit: usize, format: &str, scope: &SearchScope) -> Result<()> {
-    let start = Instant::now();
-
     // Try to use index first
     let db_path = db::get_db_path(root)?;
     if db_path.exists() {
@@ -517,7 +480,6 @@ pub fn cmd_usages(root: &Path, symbol: &str, limit: usize, format: &str, scope: 
                 println!("  No usages found in index.");
             }
 
-            eprintln!("\n{}", format!("Time: {:?} (indexed)", start.elapsed()).dimmed());
             return Ok(());
         }
     }
@@ -568,6 +530,5 @@ pub fn cmd_usages(root: &Path, symbol: &str, limit: usize, format: &str, scope: 
         println!("  No usages found.");
     }
 
-    eprintln!("\n{}", format!("Time: {:?} (grep)", start.elapsed()).dimmed());
     Ok(())
 }

--- a/src/commands/ios.rs
+++ b/src/commands/ios.rs
@@ -10,7 +10,6 @@
 
 use std::collections::HashMap;
 use std::path::Path;
-use std::time::Instant;
 
 use anyhow::Result;
 use colored::Colorize;
@@ -21,8 +20,6 @@ use crate::db;
 
 /// Find storyboard usages of a class
 pub fn cmd_storyboard_usages(root: &Path, class_name: &str, module: Option<&str>) -> Result<()> {
-    let start = Instant::now();
-
     if !db::db_exists(root) {
         println!(
             "{}",
@@ -118,7 +115,6 @@ pub fn cmd_storyboard_usages(root: &Path, class_name: &str, module: Option<&str>
         }
     }
 
-    eprintln!("\n{}", format!("Time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }
 
@@ -130,8 +126,6 @@ pub fn cmd_asset_usages(
     asset_type: Option<&str>,
     unused: bool,
 ) -> Result<()> {
-    let start = Instant::now();
-
     if !db::db_exists(root) {
         println!(
             "{}",
@@ -270,7 +264,6 @@ pub fn cmd_asset_usages(
         }
     }
 
-    eprintln!("\n{}", format!("Time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }
 
@@ -278,8 +271,6 @@ pub fn cmd_asset_usages(
 /// Finds any `@Wrapper var/let` property, not limited to a fixed list of wrappers.
 pub fn cmd_swiftui(root: &Path, query: Option<&str>, limit: usize) -> Result<()> {
     use crate::parsers::treesitter::swift::find_property_wrappers;
-
-    let start = Instant::now();
 
     // Use grep to find candidate files (fast), then tree-sitter for precise extraction
     let mut swift_files: std::collections::HashSet<std::path::PathBuf> =
@@ -350,7 +341,6 @@ pub fn cmd_swiftui(root: &Path, query: Option<&str>, limit: usize) -> Result<()>
         }
     }
 
-    eprintln!("\n{}", format!("Time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }
 
@@ -358,8 +348,6 @@ pub fn cmd_swiftui(root: &Path, query: Option<&str>, limit: usize) -> Result<()>
 /// Handles multi-line signatures natively.
 pub fn cmd_async_funcs(root: &Path, query: Option<&str>, limit: usize) -> Result<()> {
     use crate::parsers::treesitter::swift::find_async_funcs;
-
-    let start = Instant::now();
 
     let mut results: Vec<(String, String, usize)> = vec![];
 
@@ -400,14 +388,11 @@ pub fn cmd_async_funcs(root: &Path, query: Option<&str>, limit: usize) -> Result
         println!("  {}: {}:{}", func_name.cyan(), path, line_num);
     }
 
-    eprintln!("\n{}", format!("Time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }
 
 /// Find Combine publishers (PassthroughSubject, CurrentValueSubject, AnyPublisher)
 pub fn cmd_publishers(root: &Path, query: Option<&str>, limit: usize) -> Result<()> {
-    let start = Instant::now();
-
     // Search for Combine publishers: PassthroughSubject, CurrentValueSubject, AnyPublisher, Published
     let pattern = r"(PassthroughSubject|CurrentValueSubject|AnyPublisher|@Published)\s*[<(]";
 
@@ -452,14 +437,11 @@ pub fn cmd_publishers(root: &Path, query: Option<&str>, limit: usize) -> Result<
         println!("    {}", content.dimmed());
     }
 
-    eprintln!("\n{}", format!("Time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }
 
 /// Find @MainActor usages
 pub fn cmd_main_actor(root: &Path, query: Option<&str>, limit: usize) -> Result<()> {
-    let start = Instant::now();
-
     // Search for @MainActor
     let pattern = r"@MainActor";
 
@@ -491,6 +473,5 @@ pub fn cmd_main_actor(root: &Path, query: Option<&str>, limit: usize) -> Result<
         println!("    {}", content);
     }
 
-    eprintln!("\n{}", format!("Time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }

--- a/src/commands/management.rs
+++ b/src/commands/management.rs
@@ -121,8 +121,6 @@ pub fn cmd_rebuild(root: &Path, index_type: &str, index_deps: bool, no_ignore: b
         }
     }
 
-    let start = Instant::now();
-
     // Acquire exclusive lock to prevent concurrent rebuilds
     if verbose {
         eprintln!("[verbose] acquiring rebuild lock...");
@@ -394,7 +392,6 @@ pub fn cmd_rebuild(root: &Path, index_type: &str, index_deps: bool, no_ignore: b
         }
     }
 
-    eprintln!("\n{}", format!("Time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }
 
@@ -411,8 +408,6 @@ fn cmd_rebuild_sub_projects(
     config_include: Option<&[String]>,
     exclude_matcher: Option<&ignore::gitignore::Gitignore>,
 ) -> Result<()> {
-    let start = Instant::now();
-
     // Acquire exclusive lock to prevent concurrent rebuilds
     if verbose { eprintln!("[verbose] sub-projects: acquiring lock..."); }
     let t = Instant::now();
@@ -551,14 +546,11 @@ fn cmd_rebuild_sub_projects(
             success_count, total_files, module_count, dep_count, trans_count, fail_count
         ).green()
     );
-    eprintln!("{}", format!("Total time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }
 
 /// Incrementally update the index
 pub fn cmd_update(root: &Path) -> Result<()> {
-    let start = Instant::now();
-
     if !db::db_exists(root) {
         println!(
             "{}",
@@ -587,7 +579,6 @@ pub fn cmd_update(root: &Path) -> Result<()> {
         );
     }
 
-    eprintln!("\n{}", format!("Time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }
 

--- a/src/commands/modules.rs
+++ b/src/commands/modules.rs
@@ -8,7 +8,6 @@
 
 use std::collections::HashMap;
 use std::path::Path;
-use std::time::Instant;
 
 use anyhow::Result;
 use colored::Colorize;
@@ -21,8 +20,6 @@ use crate::indexer;
 
 /// Find modules by pattern
 pub fn cmd_module(root: &Path, pattern: &str, limit: usize) -> Result<()> {
-    let start = Instant::now();
-
     if !db::db_exists(root) {
         println!(
             "{}",
@@ -51,14 +48,11 @@ pub fn cmd_module(root: &Path, pattern: &str, limit: usize) -> Result<()> {
         println!("  No modules found.");
     }
 
-    eprintln!("\n{}", format!("Time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }
 
 /// Show module dependencies
 pub fn cmd_deps(root: &Path, module: &str) -> Result<()> {
-    let start = Instant::now();
-
     if !db::db_exists(root) {
         println!(
             "{}",
@@ -117,14 +111,11 @@ pub fn cmd_deps(root: &Path, module: &str) -> Result<()> {
         println!("  No dependencies found.");
     }
 
-    eprintln!("\n{}", format!("Time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }
 
 /// Show modules that depend on a module
 pub fn cmd_dependents(root: &Path, module: &str) -> Result<()> {
-    let start = Instant::now();
-
     if !db::db_exists(root) {
         println!(
             "{}",
@@ -183,7 +174,6 @@ pub fn cmd_dependents(root: &Path, module: &str) -> Result<()> {
         println!("  No dependents found.");
     }
 
-    eprintln!("\n{}", format!("Time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }
 
@@ -196,8 +186,6 @@ pub fn cmd_unused_deps(
     check_xml: bool,
     check_resources: bool,
 ) -> Result<()> {
-    let start = Instant::now();
-
     if !db::db_exists(root) {
         println!("{}", "Index not found. Run 'ast-index rebuild' first.".red());
         return Ok(());
@@ -528,7 +516,6 @@ pub fn cmd_unused_deps(
         println!("  - Exported (api): {}", exported.len());
     }
 
-    eprintln!("\n{}", format!("Time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }
 

--- a/src/commands/perl.rs
+++ b/src/commands/perl.rs
@@ -8,7 +8,6 @@
 //! - perl_imports: Find use/require statements
 
 use std::path::Path;
-use std::time::Instant;
 
 use anyhow::Result;
 use colored::Colorize;
@@ -17,8 +16,6 @@ use super::{search_files_limited, relative_path};
 
 /// Find Perl @EXPORT and @EXPORT_OK definitions
 pub fn cmd_perl_exports(root: &Path, query: Option<&str>, limit: usize) -> Result<()> {
-    let start = Instant::now();
-
     // Search for @EXPORT and @EXPORT_OK definitions
     let pattern = r"our\s+@EXPORT|our\s+@EXPORT_OK|@EXPORT\s*=|@EXPORT_OK\s*=";
 
@@ -46,14 +43,11 @@ pub fn cmd_perl_exports(root: &Path, query: Option<&str>, limit: usize) -> Resul
         println!("    {}", content);
     }
 
-    eprintln!("\n{}", format!("Time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }
 
 /// Find Perl subroutine definitions
 pub fn cmd_perl_subs(root: &Path, query: Option<&str>, limit: usize) -> Result<()> {
-    let start = Instant::now();
-
     // Search for sub definitions
     let pattern = r"^\s*sub\s+\w+";
 
@@ -81,14 +75,11 @@ pub fn cmd_perl_subs(root: &Path, query: Option<&str>, limit: usize) -> Result<(
         println!("    {}", content);
     }
 
-    eprintln!("\n{}", format!("Time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }
 
 /// Find POD documentation sections
 pub fn cmd_perl_pod(root: &Path, query: Option<&str>, limit: usize) -> Result<()> {
-    let start = Instant::now();
-
     // Search for POD documentation sections
     // =head1, =head2, =head3, =head4, =item, =over, =back, =pod, =cut, =begin, =end
     let pattern = r"^=(head[1-4]|item|over|back|pod|cut|begin|end|for)\b";
@@ -117,14 +108,11 @@ pub fn cmd_perl_pod(root: &Path, query: Option<&str>, limit: usize) -> Result<()
         println!("    {}", content);
     }
 
-    eprintln!("\n{}", format!("Time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }
 
 /// Find Perl test assertions (Test::More, Test::Simple)
 pub fn cmd_perl_tests(root: &Path, query: Option<&str>, limit: usize) -> Result<()> {
-    let start = Instant::now();
-
     // Search for Test::More and Test::Simple assertions
     // ok(), is(), isnt(), like(), unlike(), cmp_ok(), is_deeply(), diag(), pass(), fail()
     // subtest, plan, done_testing, SKIP, TODO
@@ -154,14 +142,11 @@ pub fn cmd_perl_tests(root: &Path, query: Option<&str>, limit: usize) -> Result<
         println!("    {}", content);
     }
 
-    eprintln!("\n{}", format!("Time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }
 
 /// Find Perl use/require statements
 pub fn cmd_perl_imports(root: &Path, query: Option<&str>, limit: usize) -> Result<()> {
-    let start = Instant::now();
-
     // Search for use/require statements
     let pattern = r"^\s*(use|require)\s+[A-Za-z]";
 
@@ -202,6 +187,5 @@ pub fn cmd_perl_imports(root: &Path, query: Option<&str>, limit: usize) -> Resul
         println!("    {}", content);
     }
 
-    eprintln!("\n{}", format!("Time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }

--- a/src/commands/project_info.rs
+++ b/src/commands/project_info.rs
@@ -5,7 +5,6 @@
 
 use std::collections::HashMap;
 use std::path::Path;
-use std::time::Instant;
 
 use anyhow::Result;
 use colored::Colorize;
@@ -190,8 +189,6 @@ pub fn cmd_map(
     limit: usize,
     format: &str,
 ) -> Result<()> {
-    let start = Instant::now();
-
     if !db::db_exists(root) {
         println!("{}", "Index not found. Run 'ast-index rebuild' first.".red());
         return Ok(());
@@ -209,7 +206,6 @@ pub fn cmd_map(
         cmd_map_summary(&conn, &project_type, &stats, limit, depth, format)?;
     }
 
-    eprintln!("{}", format!("Time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }
 
@@ -671,8 +667,6 @@ const ARCH_PATTERNS: &[(&[&str], &str)] = &[
 ];
 
 pub fn cmd_conventions(root: &Path, format: &str) -> Result<()> {
-    let start = Instant::now();
-
     if !db::db_exists(root) {
         println!("{}", "Index not found. Run 'ast-index rebuild' first.".red());
         return Ok(());
@@ -814,6 +808,5 @@ pub fn cmd_conventions(root: &Path, format: &str) -> Result<()> {
         println!();
     }
 
-    eprintln!("{}", format!("Time: {:?}", start.elapsed()).dimmed());
     Ok(())
 }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -882,12 +882,8 @@ pub fn index_directory_scoped(conn: &mut Connection, root: &Path, walk_dir: &Pat
         if verbose { eprintln!("[verbose] chunk {}/{}: written in {:?}", chunk_idx + 1, total_chunks, write_start.elapsed()); }
 
         if progress {
-            eprintln!("Written {} / {} files to DB...", total_count, total_files);
+            eprintln!("Written {} / {} files to DB", total_count, total_files);
         }
-    }
-
-    if progress {
-        eprintln!("Written {} / {} files to DB", total_count, total_files);
     }
 
     Ok(WalkResult {


### PR DESCRIPTION
## Summary

- Drop trailing `Time: …` line from every query/search command (35+ sites) — pure dev-debug noise that pollutes coding-agent context on every call
- Drop the timing breakdown (`Time: X (files: …, symbols: …, refs: …, content: …)`) from `cmd_search`
- Fix duplicate `Written N / N files to DB` that printed both inside the chunk loop and once more after it

Users who want timing can prefix with `time ast-index …`.

Net diff: 169 lines removed, 1 added.

## Test plan
- [x] `cargo build --release` — clean (same 4 pre-existing unrelated warnings)
- [x] `cargo test --release` — 596 / 596 pass
- [x] Smoke-tested `rebuild`, `update`, `search`, `symbol`, `class`, `outline`, `imports`, `usages`, `refs`, `stats`, `file`, `implementations`, `hierarchy`, `map`, `conventions`, `todo`, `module`, `unused-symbols`, `changed` — no `Time:` trailer, no duplicate `Written` line

🤖 Generated with [Claude Code](https://claude.com/claude-code)