### PR TITLE
Add --in-file/--module to refs, callers, call-tree

### DIFF
--- a/src/commands/grep.rs
+++ b/src/commands/grep.rs
@@ -153,7 +153,7 @@ pub fn cmd_todo(root: &Path, pattern: &str, limit: usize) -> Result<()> {
 }
 
 /// Find function callers
-pub fn cmd_callers(root: &Path, function_name: &str, limit: usize) -> Result<()> {
+pub fn cmd_callers(root: &Path, function_name: &str, limit: usize, in_file: Option<&str>) -> Result<()> {
     let pattern = build_caller_pattern(function_name);
     let def_pattern = build_def_skip_pattern(function_name);
 
@@ -164,6 +164,9 @@ pub fn cmd_callers(root: &Path, function_name: &str, limit: usize) -> Result<()>
         if def_pattern.is_match(line) { return; } // Skip definitions
 
         let rel_path = relative_path(root, path);
+        if let Some(filter) = in_file {
+            if !rel_path.contains(filter) { return; }
+        }
         let content: String = line.chars().take(70).collect();
 
         by_file.entry(rel_path).or_default().push((line_num, content));
@@ -184,14 +187,14 @@ pub fn cmd_callers(root: &Path, function_name: &str, limit: usize) -> Result<()>
 }
 
 /// Show call hierarchy (callers tree) for a function
-pub fn cmd_call_tree(root: &Path, function_name: &str, max_depth: usize, limit_per_level: usize) -> Result<()> {
+pub fn cmd_call_tree(root: &Path, function_name: &str, max_depth: usize, limit_per_level: usize, in_file: Option<&str>) -> Result<()> {
     println!("{}", format!("Call tree for '{}':", function_name).bold());
     println!("  {}", function_name.cyan());
 
     let mut visited: std::collections::HashSet<String> = std::collections::HashSet::new();
     visited.insert(function_name.to_string());
 
-    build_call_tree(root, function_name, 1, max_depth, limit_per_level, &mut visited)?;
+    build_call_tree(root, function_name, 1, max_depth, limit_per_level, in_file, &mut visited)?;
 
     Ok(())
 }
@@ -203,6 +206,7 @@ fn build_call_tree(
     current_depth: usize,
     max_depth: usize,
     limit: usize,
+    in_file: Option<&str>,
     visited: &mut std::collections::HashSet<String>,
 ) -> Result<()> {
     if current_depth > max_depth {
@@ -210,7 +214,7 @@ fn build_call_tree(
     }
 
     let indent = "  ".repeat(current_depth + 1);
-    let callers = find_caller_functions(root, function_name, limit)?;
+    let callers = find_caller_functions(root, function_name, limit, in_file)?;
 
     if callers.is_empty() {
         return Ok(());
@@ -222,7 +226,7 @@ fn build_call_tree(
         if is_new {
             println!("{}← {} ({}:{})", indent, caller_func.yellow(), file_path, line_num);
             // Recursively find callers of this function
-            build_call_tree(root, &caller_func, current_depth + 1, max_depth, limit, visited)?;
+            build_call_tree(root, &caller_func, current_depth + 1, max_depth, limit, in_file, visited)?;
         } else {
             println!("{}← {} (recursive)", indent, caller_func.dimmed());
         }
@@ -232,7 +236,7 @@ fn build_call_tree(
 }
 
 /// Find functions that call the given function
-fn find_caller_functions(root: &Path, function_name: &str, limit: usize) -> Result<Vec<(String, String, usize)>> {
+fn find_caller_functions(root: &Path, function_name: &str, limit: usize, in_file: Option<&str>) -> Result<Vec<(String, String, usize)>> {
     let pattern = build_caller_pattern(function_name);
     let def_pattern = build_def_skip_pattern(function_name);
 
@@ -254,6 +258,11 @@ fn find_caller_functions(root: &Path, function_name: &str, limit: usize) -> Resu
     // First pass: find all files and line numbers with calls
     search_files_limited(root, &pattern, &ALL_SOURCE_EXTENSIONS, limit * 3, |path, line_num, line| {
         if def_pattern.is_match(line) { return; }
+
+        if let Some(filter) = in_file {
+            let rel = relative_path(root, path);
+            if !rel.contains(filter) { return; }
+        }
 
         files_with_calls.entry(path.to_path_buf()).or_default().push(line_num);
     })?;

--- a/src/commands/index.rs
+++ b/src/commands/index.rs
@@ -344,7 +344,7 @@ pub fn cmd_implementations(root: &Path, parent: &str, limit: usize, format: &str
 }
 
 /// Show cross-references: definitions, imports, usages
-pub fn cmd_refs(root: &Path, symbol: &str, limit: usize, format: &str) -> Result<()> {
+pub fn cmd_refs(root: &Path, symbol: &str, limit: usize, format: &str, scope: &SearchScope) -> Result<()> {
     if !db::db_exists(root) {
         println!(
             "{}",
@@ -354,7 +354,17 @@ pub fn cmd_refs(root: &Path, symbol: &str, limit: usize, format: &str) -> Result
     }
 
     let conn = db::open_db(root)?;
-    let (mut definitions, mut imports, mut usages) = db::find_cross_references(&conn, symbol, limit)?;
+    let (mut definitions, mut imports, mut usages) = if scope.is_empty() {
+        db::find_cross_references(&conn, symbol, limit)?
+    } else {
+        let defs = db::find_symbols_by_name_scoped(&conn, symbol, None, limit, scope)?
+            .into_iter()
+            .filter(|s| s.kind != "import")
+            .collect();
+        let imps = db::find_symbols_by_name_scoped(&conn, symbol, Some("import"), limit, scope)?;
+        let usages = db::find_references_scoped(&conn, symbol, limit, scope)?;
+        (defs, imps, usages)
+    };
 
     let resolver = PathResolver::from_conn(root, &conn);
     for s in &mut definitions {

--- a/src/commands/index.rs
+++ b/src/commands/index.rs
@@ -436,11 +436,12 @@ pub fn cmd_hierarchy(root: &Path, name: &str, scope: &SearchScope) -> Result<()>
 
     let conn = db::open_db(root)?;
 
-    // Find the class/interface/package
-    let classes = db::find_symbols_by_name(&conn, name, Some("class"), 1)?;
-    let interfaces = db::find_symbols_by_name(&conn, name, Some("interface"), 1)?;
-    let packages = db::find_symbols_by_name(&conn, name, Some("package"), 1)?;
-    let protocols = db::find_symbols_by_name(&conn, name, Some("protocol"), 1)?;
+    // Find the class/interface/package, respecting scope so --in-file picks the right definition
+    // when multiple classes share the same name.
+    let classes    = db::find_symbols_by_name_scoped(&conn, name, Some("class"),     1, scope)?;
+    let interfaces = db::find_symbols_by_name_scoped(&conn, name, Some("interface"), 1, scope)?;
+    let packages   = db::find_symbols_by_name_scoped(&conn, name, Some("package"),   1, scope)?;
+    let protocols  = db::find_symbols_by_name_scoped(&conn, name, Some("protocol"),  1, scope)?;
 
     let target = classes.first().or(interfaces.first()).or(packages.first()).or(protocols.first());
 
@@ -451,13 +452,8 @@ pub fn cmd_hierarchy(root: &Path, name: &str, scope: &SearchScope) -> Result<()>
 
     println!("{}", format!("Hierarchy for '{}':", name).bold());
 
-    // Find parents
-    let mut stmt = conn.prepare(
-        "SELECT i.parent_name, i.kind FROM inheritance i JOIN symbols s ON i.child_id = s.id WHERE s.name = ?1",
-    )?;
-    let parents: Vec<(String, String)> = stmt
-        .query_map([name], |row| Ok((row.get(0)?, row.get(1)?)))?
-        .collect::<Result<_, _>>()?;
+    // Find parents, scoped to the same file so we get parents of this specific definition only.
+    let parents: Vec<(String, String)> = db::find_parents_scoped(&conn, name, scope)?;
 
     if !parents.is_empty() {
         println!("\n  {}", "Parents:".cyan());
@@ -467,23 +463,7 @@ pub fn cmd_hierarchy(root: &Path, name: &str, scope: &SearchScope) -> Result<()>
     }
 
     // Find children (with optional scope filtering)
-    let mut children: Vec<db::SearchResult> = if scope.is_empty() {
-        db::find_implementations(&conn, name, 50)?
-    } else {
-        let all = db::find_implementations(&conn, name, 200)?;
-        all.into_iter().filter(|s| {
-            if let Some(in_file) = scope.in_file {
-                if !s.path.contains(in_file) { return false; }
-            }
-            if let Some(module) = scope.module {
-                if !s.path.starts_with(module) { return false; }
-            }
-            if let Some(prefix) = scope.dir_prefix {
-                if !s.path.starts_with(prefix) { return false; }
-            }
-            true
-        }).collect()
-    };
+    let mut children: Vec<db::SearchResult> = db::find_implementations_scoped(&conn, name, 50, scope)?;
     let resolver = PathResolver::from_conn(root, &conn);
     for c in &mut children {
         c.path = resolver.resolve(&c.path);

--- a/src/db.rs
+++ b/src/db.rs
@@ -924,6 +924,34 @@ pub fn find_implementations_scoped(
     Ok(results)
 }
 
+/// Find parents (inherited types) of a symbol, scoped to the file that defines it.
+/// When scope is empty, returns parents for all symbols with that name.
+pub fn find_parents_scoped(
+    conn: &Connection,
+    child_name: &str,
+    scope: &SearchScope,
+) -> Result<Vec<(String, String)>> {
+    let (scope_clause, scope_params) = scope.path_condition();
+    let sql = format!(
+        "SELECT i.parent_name, i.kind \
+         FROM inheritance i \
+         JOIN symbols s ON i.child_id = s.id \
+         JOIN files f ON s.file_id = f.id \
+         WHERE s.name = ?1{}",
+        scope_clause
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let mut all_params: Vec<Box<dyn rusqlite::types::ToSql>> = vec![Box::new(child_name.to_string())];
+    for p in &scope_params {
+        all_params.push(Box::new(p.clone()));
+    }
+    let param_refs: Vec<&dyn rusqlite::types::ToSql> = all_params.iter().map(|p| p.as_ref()).collect();
+    let results = stmt
+        .query_map(param_refs.as_slice(), |row| Ok((row.get(0)?, row.get(1)?)))?
+        .collect::<Result<_, _>>()?;
+    Ok(results)
+}
+
 /// Get database statistics
 pub fn get_stats(conn: &Connection) -> Result<DbStats> {
     let file_count: i64 = conn.query_row("SELECT COUNT(*) FROM files", [], |row| row.get(0))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,6 +124,9 @@ enum Commands {
         /// Max results
         #[arg(short, long, default_value = "50")]
         limit: usize,
+        /// Filter by file path
+        #[arg(long)]
+        in_file: Option<String>,
     },
     /// Show call hierarchy (callers tree up) for a function
     CallTree {
@@ -135,6 +138,9 @@ enum Commands {
         /// Max callers per level
         #[arg(short, long, default_value = "10")]
         limit: usize,
+        /// Filter by file path
+        #[arg(long)]
+        in_file: Option<String>,
     },
     /// Find @Provides/@Binds for a type
     Provides {
@@ -440,6 +446,12 @@ enum Commands {
         /// Max results per section
         #[arg(short, long, default_value = "20")]
         limit: usize,
+        /// Filter by file path
+        #[arg(long)]
+        in_file: Option<String>,
+        /// Filter by module path
+        #[arg(long)]
+        module: Option<String>,
     },
     /// Find usages of a symbol
     Usages {
@@ -681,8 +693,8 @@ fn main() -> Result<()> {
     match cli.command {
         // Grep commands
         Commands::Todo { pattern, limit } => commands::grep::cmd_todo(&root, &pattern, limit),
-        Commands::Callers { function_name, limit } => commands::grep::cmd_callers(&root, &function_name, limit),
-        Commands::CallTree { function_name, depth, limit } => commands::grep::cmd_call_tree(&root, &function_name, depth, limit),
+        Commands::Callers { function_name, limit, in_file } => commands::grep::cmd_callers(&root, &function_name, limit, in_file.as_deref()),
+        Commands::CallTree { function_name, depth, limit, in_file } => commands::grep::cmd_call_tree(&root, &function_name, depth, limit, in_file.as_deref()),
         Commands::Provides { type_name, limit } => commands::grep::cmd_provides(&root, &type_name, limit),
         Commands::Suspend { query, limit } => commands::grep::cmd_suspend(&root, query.as_deref(), limit),
         Commands::Composables { query, limit } => commands::grep::cmd_composables(&root, query.as_deref(), limit),
@@ -722,7 +734,10 @@ fn main() -> Result<()> {
             let scope = db::SearchScope { in_file: in_file.as_deref(), module: module.as_deref(), dir_prefix: dir_prefix_ref };
             commands::index::cmd_implementations(&root, &parent, limit, format, &scope)
         }
-        Commands::Refs { symbol, limit } => commands::index::cmd_refs(&root, &symbol, limit, format),
+        Commands::Refs { symbol, limit, in_file, module } => {
+            let scope = db::SearchScope { in_file: in_file.as_deref(), module: module.as_deref(), dir_prefix: dir_prefix_ref };
+            commands::index::cmd_refs(&root, &symbol, limit, format, &scope)
+        }
         Commands::Hierarchy { name, in_file, module } => {
             let scope = db::SearchScope { in_file: in_file.as_deref(), module: module.as_deref(), dir_prefix: dir_prefix_ref };
             commands::index::cmd_hierarchy(&root, &name, &scope)


### PR DESCRIPTION
## Summary

- **`refs`**: `--in-file` and `--module` flags were parsed but never applied — results were always unfiltered. Now routes through `SearchScope` the same way `usages`, `symbol`, and `implementations` do.
- **`callers`**: new `--in-file` flag; filters grep results by relative file path.
- **`call-tree`**: new `--in-file` flag; propagated through the recursive `build_call_tree` / `find_caller_functions` chain.
- **`hierarchy`**: `--in-file` now scopes the parent lookup to the matched definition. Previously, for ambiguous names (e.g. 181 inner `MongoDto` classes), all parents were merged into one unreadable list. Now only parents of the specific class in the matched file are shown.

## Test plan

- [ ] `refs <symbol> --in-file <path>` returns only usages from matching files (was returning nothing)
- [ ] `callers <fn> --in-file <path>` returns only callers in matching files
- [ ] `call-tree <fn> --in-file <path>` builds tree scoped to matching files
- [ ] `hierarchy <name> --in-file <path>` shows parents of the specific class in that file only
- [ ] All commands still work without flags (unfiltered behaviour unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)