### PR TITLE
Add fixture-based integration test framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,7 @@ dependencies = [
  "grep-regex",
  "grep-searcher",
  "ignore",
+ "libtest-mimic",
  "notify",
  "notify-debouncer-mini",
  "parking_lot",
@@ -443,6 +444,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "escape8259"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5692dd7b5a1978a5aeb0ce83b7655c58ca8efdcb79d21036ea249da95afec2c6"
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -774,6 +781,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libtest-mimic"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc0bda45ed5b3a2904262c1bb91e526127aa70e7ef3758aba2ef93cf896b9b58"
+dependencies = [
+ "clap",
+ "escape8259",
+ "termcolor",
+ "threadpool",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -868,6 +887,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -1297,6 +1326,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1314,6 +1352,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,11 @@ cc = "1"
 tempfile = "3"
 criterion = { version = "0.5", features = ["html_reports"] }
 proptest = "1"
+libtest-mimic = "0.7"
+
+[[test]]
+name = "fixture_runner"
+harness = false
 
 [[bench]]
 name = "parser_bench"

--- a/tests/fixture_runner.rs
+++ b/tests/fixture_runner.rs
@@ -1,0 +1,124 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Arc;
+
+use libtest_mimic::{Arguments, Failed, Trial};
+use serde::Deserialize;
+use tempfile::TempDir;
+
+#[derive(Deserialize)]
+struct TestCase {
+    #[serde(default)]
+    description: Option<String>,
+    command: Vec<String>,
+    #[serde(default)]
+    out: Vec<String>,
+}
+
+fn fixtures_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures")
+}
+
+fn run_ast_index(fixture: &Path, db_path: &Path, args: &[&str]) -> (bool, String, String) {
+    let output = Command::new(env!("CARGO_BIN_EXE_ast-index"))
+        .args(args)
+        .current_dir(fixture)
+        .env("AST_INDEX_DB_PATH", db_path)
+        .output()
+        .expect("failed to spawn ast-index");
+    (
+        output.status.success(),
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+// Result lines carry indexed data (e.g. "UserService [class]: …").
+// Headers ("Symbols matching …") and blank lines are skipped.
+fn is_result_line(line: &str) -> bool {
+    let t = line.trim();
+    t.contains('[') && t.contains("]:")
+}
+
+fn collect_trials(dir: &Path, root: &Path, trials: &mut Vec<Trial>) {
+    let yaml_path = dir.join("tests.yaml");
+    if yaml_path.exists() {
+        let rel = dir.strip_prefix(root).unwrap().to_string_lossy().into_owned();
+        let yaml = fs::read_to_string(&yaml_path)
+            .unwrap_or_else(|e| panic!("can't read {}: {e}", yaml_path.display()));
+        let cases: Vec<TestCase> = serde_yaml::from_str(&yaml)
+            .unwrap_or_else(|e| panic!("invalid tests.yaml in {rel}: {e}"));
+
+        let db_dir = Arc::new(TempDir::new().expect("tempdir"));
+        let db_path = db_dir.path().join("index.db");
+        let fixture = dir.to_path_buf();
+
+        let (ok, stdout, stderr) = run_ast_index(&fixture, &db_path, &["rebuild"]);
+        assert!(ok, "rebuild failed for {rel}:\nstdout: {stdout}\nstderr: {stderr}");
+
+        for case in cases {
+            let name = format!("{rel} | {}", case.command.join(" "));
+            let fixture = fixture.clone();
+            let db_dir = Arc::clone(&db_dir);
+            let db_path = db_path.clone();
+
+            trials.push(Trial::test(name, move || {
+                let _ = &db_dir; // keep TempDir alive for the duration of the trial
+                let args: Vec<&str> = case.command.iter().map(String::as_str).collect();
+                let (_, stdout, stderr) = run_ast_index(&fixture, &db_path, &args);
+
+                let mut errors = Vec::new();
+
+                for entry in &case.out {
+                    if !stdout.lines().any(|l| l.trim().contains(entry.as_str())) {
+                        errors.push(format!("  missing:    {entry:?}"));
+                    }
+                }
+                for line in stdout.lines().filter(|l| is_result_line(l)) {
+                    if !case.out.iter().any(|e| line.trim().contains(e.as_str())) {
+                        errors.push(format!("  unexpected: {:?}", line.trim()));
+                    }
+                }
+
+                if errors.is_empty() {
+                    Ok(())
+                } else {
+                    let mut msg = errors.join("\n");
+                    if let Some(desc) = &case.description {
+                        msg = format!("{desc}\n{msg}");
+                    }
+                    msg.push_str(&format!(
+                        "\n  stdout:\n{}",
+                        stdout.lines().map(|l| format!("    {l}")).collect::<Vec<_>>().join("\n"),
+                    ));
+                    if !stderr.trim().is_empty() {
+                        msg.push_str(&format!("\n  stderr: {}", stderr.trim()));
+                    }
+                    Err(Failed::from(msg))
+                }
+            }));
+        }
+    }
+
+    if let Ok(mut entries) = fs::read_dir(dir) {
+        let mut subdirs: Vec<PathBuf> = entries
+            .by_ref()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
+            .map(|e| e.path())
+            .collect();
+        subdirs.sort();
+        for sub in subdirs {
+            collect_trials(&sub, root, trials);
+        }
+    }
+}
+
+fn main() {
+    let args = Arguments::from_args();
+    let root = fixtures_root();
+    let mut trials = Vec::new();
+    collect_trials(&root, &root, &mut trials);
+    libtest_mimic::run(&args, trials).exit();
+}

--- a/tests/fixtures/java/java-main-test/Main.java
+++ b/tests/fixtures/java/java-main-test/Main.java
@@ -1,0 +1,7 @@
+public class Main {
+    public static void main(String[] args) {
+        UserService service = new UserService();
+        User user = service.findById(1L);
+        System.out.println(user.name());
+    }
+}

--- a/tests/fixtures/java/java-main-test/User.java
+++ b/tests/fixtures/java/java-main-test/User.java
@@ -1,0 +1,1 @@
+public record User(Long id, String name, String email) {}

--- a/tests/fixtures/java/java-main-test/UserService.java
+++ b/tests/fixtures/java/java-main-test/UserService.java
@@ -1,0 +1,22 @@
+import java.util.List;
+
+public interface UserRepository {
+    User findById(Long id);
+    User save(User user);
+}
+
+public class UserService implements UserRepository {
+    @Override
+    public User findById(Long id) {
+        return new User(id, "Alice", "alice@example.com");
+    }
+
+    @Override
+    public User save(User user) {
+        return user;
+    }
+
+    public List<User> findAll() {
+        return List.of();
+    }
+}

--- a/tests/fixtures/java/java-main-test/pom.xml
+++ b/tests/fixtures/java/java-main-test/pom.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <groupId>com.example</groupId>
+    <artifactId>java-main-test</artifactId>
+    <version>1.0.0</version>
+</project>

--- a/tests/fixtures/java/java-main-test/tests.yaml
+++ b/tests/fixtures/java/java-main-test/tests.yaml
@@ -1,0 +1,33 @@
+- command: [symbol, Main]
+  out:
+    - "Main [class]:"
+
+- command: [symbol, UserService]
+  out:
+    - "UserService [class]:"
+
+- command: [symbol, UserRepository]
+  out:
+    - "UserRepository [interface]:"
+
+- command: [symbol, User]
+  out:
+    - "User [class]:"
+
+- command: [symbol, findById]
+  out:
+    - "findById [function]:"
+
+- command: [symbol, findAll]
+  out:
+    - "findAll [function]:"
+
+- command: [symbol, email]
+  out:
+    - "email [property]:"
+    - "email [function]:"
+
+- command: [search, UserService]
+  out:
+    - "UserService [class]:"
+


### PR DESCRIPTION
## Summary

- Adds `tests/fixture_runner.rs` — custom test harness (`harness = false`) using `libtest-mimic` that discovers all `tests.yaml` files under `tests/fixtures/` and registers each test case as a separate named test
- Adds `tests/fixtures/java/java-main-test/` — first fixture: a minimal Java project (class, interface, record, methods) with 8 test cases covering symbol indexing
- Adds `libtest-mimic = "0.7"` dev-dependency

## How it works

Each `tests.yaml` entry specifies a command and `out:` — the complete set of expected result lines. The runner checks both directions: every listed line must appear, and every result line in output must be covered. Headers and blank lines are ignored. `AST_INDEX_DB_PATH` is used to isolate the DB in a `TempDir` per fixture.

## Adding a new fixture

1. Create `tests/fixtures/<lang>/<project>/` with source files
2. Add `tests.yaml` with test cases
3. No changes to `.rs` files needed