### PR TITLE
Parse deps(project(":path")) style dependencies in Gradle files

### DIFF
--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1472,16 +1472,12 @@ pub fn index_module_dependencies(conn: &mut Connection, root: &Path, gradle_file
 
     let projects_dep_re = &*PROJECTS_DEP_RE;
 
-    // Standard Gradle style: implementation(project(":features:payments:api"))
-    static GRADLE_PROJECT_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r#"(?m)(api|implementation|compileOnly|testImplementation)\s*\(\s*project\s*\(\s*["']:([^"']+)["']\s*\)"#).unwrap());
+    // Gradle project(...) deps: implementation(project(":features:payments:api"))
+    // Also matches custom DSL wrappers like deps(project(":path")) used in Forma-like Gradle DSLs.
+    // Capture group 1 is the configuration/wrapper identifier; the leading `:` on the path is optional.
+    static GRADLE_PROJECT_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r#"(?m)\b(\w+)\s*\(\s*project\s*\(\s*["']:?([^"']+)["']\s*\)"#).unwrap());
 
     let gradle_project_re = &*GRADLE_PROJECT_RE;
-
-    // Custom DSL style: deps(project(":path"), project(":other")) - used in Forma-like Gradle DSLs
-    // Matches project(":path") inside deps(...) blocks
-    static DEPS_PROJECT_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r#"(?m)project\s*\(\s*["']([^"']+)["']\s*\)"#).unwrap());
-
-    let deps_project_re = &*DEPS_PROJECT_RE;
 
     // ya.make PEERDIR(...) — accepts one or more whitespace-separated paths
     static PEERDIR_RE: LazyLock<Regex> = LazyLock::new(||
@@ -1687,15 +1683,6 @@ pub fn index_module_dependencies(conn: &mut Connection, root: &Path, gradle_file
                         let dep_name = dep_path.trim_start_matches(':').replace(':', ".");
                         if let Some(&dep_id) = module_ids.get(&dep_name) {
                             dep_stmt.execute(rusqlite::params![module_id, dep_id, dep_kind])?;
-                            dep_count += 1;
-                        }
-                    }
-                    // Parse deps(project(":path")) style - used in Forma and similar Gradle DSLs
-                    for caps in deps_project_re.captures_iter(&content) {
-                        let dep_path = caps.get(1).map(|m| m.as_str()).unwrap_or("");
-                        let dep_name = dep_path.trim_start_matches(':').replace(':', ".");
-                        if let Some(&dep_id) = module_ids.get(&dep_name) {
-                            dep_stmt.execute(rusqlite::params![module_id, dep_id, "implementation"])?;
                             dep_count += 1;
                         }
                     }
@@ -3029,6 +3016,57 @@ mod tests {
         let dep_names: Vec<String> = deps.iter().map(|(n, _, _)| n.clone()).collect();
         assert!(dep_names.contains(&"lib/a".to_string()));
         assert!(dep_names.contains(&"lib/b".to_string()));
+    }
+
+    #[test]
+    fn test_index_deps_gradle_custom_dsl() {
+        // Custom DSL wrappers like deps(project(":foo")) used in Forma-like Gradle setups
+        // must be matched, but standard implementation(project(":foo")) MUST NOT produce
+        // a duplicate edge — module_deps has no UNIQUE constraint, so a regex that double-matches
+        // would silently inflate dependent counts.
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+        fs::create_dir_all(root.join("core/api")).unwrap();
+        fs::create_dir_all(root.join("core/impl")).unwrap();
+        fs::create_dir_all(root.join("feature/login")).unwrap();
+        fs::write(root.join("core/api/build.gradle.kts"), "").unwrap();
+        fs::write(root.join("core/impl/build.gradle.kts"), "").unwrap();
+        // Mix of custom DSL `deps(project(...))` and standard `implementation(project(...))`.
+        // The standard form must contribute exactly one edge, not two.
+        fs::write(
+            root.join("feature/login/build.gradle.kts"),
+            r#"
+            plugins { id("forma") }
+            deps(
+                project(":core:api"),
+            )
+            dependencies {
+                implementation(project(":core:impl"))
+            }
+            "#,
+        )
+        .unwrap();
+
+        let mut conn = Connection::open_in_memory().unwrap();
+        db::init_db(&conn).unwrap();
+
+        let files = vec![
+            root.join("core/api/build.gradle.kts"),
+            root.join("core/impl/build.gradle.kts"),
+            root.join("feature/login/build.gradle.kts"),
+        ];
+        index_modules_from_files(&conn, root, &files).unwrap();
+        let dep_count = index_module_dependencies(&mut conn, root, &files, false).unwrap();
+
+        let deps = get_module_deps(&conn, "feature.login").unwrap();
+        let dep_names: Vec<String> = deps.iter().map(|(n, _, _)| n.clone()).collect();
+        assert!(dep_names.contains(&"core.api".to_string()), "deps(project(...)) not parsed: {:?}", dep_names);
+        assert!(dep_names.contains(&"core.impl".to_string()), "implementation(project(...)) not parsed: {:?}", dep_names);
+
+        let impl_count = dep_names.iter().filter(|n| *n == "core.impl").count();
+        assert_eq!(impl_count, 1, "implementation(project(...)) duplicated: {:?}", dep_names);
+        assert_eq!(deps.len(), 2, "expected exactly 2 deps, got {:?}", deps);
+        assert_eq!(dep_count, 2, "dep_count mismatch");
     }
 
     #[test]

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1477,6 +1477,12 @@ pub fn index_module_dependencies(conn: &mut Connection, root: &Path, gradle_file
 
     let gradle_project_re = &*GRADLE_PROJECT_RE;
 
+    // Custom DSL style: deps(project(":path"), project(":other")) - used in Forma-like Gradle DSLs
+    // Matches project(":path") inside deps(...) blocks
+    static DEPS_PROJECT_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r#"(?m)project\s*\(\s*["']([^"']+)["']\s*\)"#).unwrap());
+
+    let deps_project_re = &*DEPS_PROJECT_RE;
+
     // ya.make PEERDIR(...) — accepts one or more whitespace-separated paths
     static PEERDIR_RE: LazyLock<Regex> = LazyLock::new(||
         Regex::new(r"(?s)PEERDIR\s*\(\s*([^)]*)\s*\)").unwrap()
@@ -1681,6 +1687,15 @@ pub fn index_module_dependencies(conn: &mut Connection, root: &Path, gradle_file
                         let dep_name = dep_path.trim_start_matches(':').replace(':', ".");
                         if let Some(&dep_id) = module_ids.get(&dep_name) {
                             dep_stmt.execute(rusqlite::params![module_id, dep_id, dep_kind])?;
+                            dep_count += 1;
+                        }
+                    }
+                    // Parse deps(project(":path")) style - used in Forma and similar Gradle DSLs
+                    for caps in deps_project_re.captures_iter(&content) {
+                        let dep_path = caps.get(1).map(|m| m.as_str()).unwrap_or("");
+                        let dep_name = dep_path.trim_start_matches(':').replace(':', ".");
+                        if let Some(&dep_id) = module_ids.get(&dep_name) {
+                            dep_stmt.execute(rusqlite::params![module_id, dep_id, "implementation"])?;
                             dep_count += 1;
                         }
                     }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1474,6 +1474,7 @@ pub fn index_module_dependencies(conn: &mut Connection, root: &Path, gradle_file
 
     // Gradle project(...) deps: implementation(project(":features:payments:api"))
     // Also matches custom DSL wrappers like deps(project(":path")) used in Forma-like Gradle DSLs.
+    // See https://github.com/formatools/forma for the Forma DSL.
     // Capture group 1 is the configuration/wrapper identifier; the leading `:` on the path is optional.
     static GRADLE_PROJECT_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r#"(?m)\b(\w+)\s*\(\s*project\s*\(\s*["']:?([^"']+)["']\s*\)"#).unwrap());
 
@@ -3019,30 +3020,62 @@ mod tests {
     }
 
     #[test]
-    fn test_index_deps_gradle_custom_dsl() {
-        // Custom DSL wrappers like deps(project(":foo")) used in Forma-like Gradle setups
-        // must be matched, but standard implementation(project(":foo")) MUST NOT produce
-        // a duplicate edge — module_deps has no UNIQUE constraint, so a regex that double-matches
-        // would silently inflate dependent counts.
+    fn test_index_deps_gradle_standard_and_forma() {
+        // Two consumer modules in one fixture:
+        //   * feature/login uses the canonical Gradle `dependencies { implementation(project(...)) }`
+        //   * feature/profile uses the Forma-style `androidLibrary(dependencies = deps(...) + deps(project(...)))`
+        // Each consumer also lists external accessors (google.material, androidx.appcompat,
+        // test.junit, test.espresso) to confirm the regex does not false-match non-project entries.
+        // module_deps has no UNIQUE constraint, so the regex must produce exactly one edge per
+        // declaration — a previous version with two overlapping patterns silently doubled
+        // standard-form edges.
         let dir = TempDir::new().unwrap();
         let root = dir.path();
-        fs::create_dir_all(root.join("core/api")).unwrap();
-        fs::create_dir_all(root.join("core/impl")).unwrap();
-        fs::create_dir_all(root.join("feature/login")).unwrap();
-        fs::write(root.join("core/api/build.gradle.kts"), "").unwrap();
-        fs::write(root.join("core/impl/build.gradle.kts"), "").unwrap();
-        // Mix of custom DSL `deps(project(...))` and standard `implementation(project(...))`.
-        // The standard form must contribute exactly one edge, not two.
+        for sub in &["core/network", "core/database", "feature/login", "feature/profile"] {
+            fs::create_dir_all(root.join(sub)).unwrap();
+        }
+        // Leaf targets — empty build files so they only register as modules.
+        fs::write(root.join("core/network/build.gradle.kts"), "").unwrap();
+        fs::write(root.join("core/database/build.gradle.kts"), "").unwrap();
+
+        // Standard Gradle consumer.
         fs::write(
             root.join("feature/login/build.gradle.kts"),
             r#"
-            plugins { id("forma") }
-            deps(
-                project(":core:api"),
-            )
-            dependencies {
-                implementation(project(":core:impl"))
+            plugins {
+                id("com.android.library")
+                kotlin("android")
             }
+            dependencies {
+                implementation(project(":core:network"))
+                implementation("androidx.appcompat:appcompat:1.6.1")
+                testImplementation("junit:junit:4.13.2")
+            }
+            "#,
+        )
+        .unwrap();
+
+        // Forma DSL consumer — mirrors the syntax shown in the Forma README
+        // (https://github.com/formatools/forma): `dependencies = deps(...) + deps(project(...))`,
+        // plus testDependencies/androidTestDependencies.
+        fs::write(
+            root.join("feature/profile/build.gradle.kts"),
+            r#"
+            androidLibrary(
+                packageName = "tools.forma.sample.profile",
+                dependencies = deps(
+                    google.material,
+                    androidx.appcompat,
+                ) + deps(
+                    project(":core:database"),
+                ),
+                testDependencies = deps(
+                    test.junit,
+                ),
+                androidTestDependencies = deps(
+                    test.espresso,
+                ),
+            )
             "#,
         )
         .unwrap();
@@ -3051,22 +3084,43 @@ mod tests {
         db::init_db(&conn).unwrap();
 
         let files = vec![
-            root.join("core/api/build.gradle.kts"),
-            root.join("core/impl/build.gradle.kts"),
+            root.join("core/network/build.gradle.kts"),
+            root.join("core/database/build.gradle.kts"),
             root.join("feature/login/build.gradle.kts"),
+            root.join("feature/profile/build.gradle.kts"),
         ];
         index_modules_from_files(&conn, root, &files).unwrap();
         let dep_count = index_module_dependencies(&mut conn, root, &files, false).unwrap();
 
-        let deps = get_module_deps(&conn, "feature.login").unwrap();
-        let dep_names: Vec<String> = deps.iter().map(|(n, _, _)| n.clone()).collect();
-        assert!(dep_names.contains(&"core.api".to_string()), "deps(project(...)) not parsed: {:?}", dep_names);
-        assert!(dep_names.contains(&"core.impl".to_string()), "implementation(project(...)) not parsed: {:?}", dep_names);
+        // feature.login — exactly one internal edge to core.network via standard Gradle DSL.
+        let login_deps = get_module_deps(&conn, "feature.login").unwrap();
+        let login_names: Vec<&str> = login_deps.iter().map(|(n, _, _)| n.as_str()).collect();
+        assert_eq!(
+            login_names,
+            vec!["core.network"],
+            "feature.login: expected only [core.network], got {:?}",
+            login_names
+        );
+        assert_eq!(login_deps[0].2, "implementation", "feature.login dep_kind mismatch: {:?}", login_deps[0]);
 
-        let impl_count = dep_names.iter().filter(|n| *n == "core.impl").count();
-        assert_eq!(impl_count, 1, "implementation(project(...)) duplicated: {:?}", dep_names);
-        assert_eq!(deps.len(), 2, "expected exactly 2 deps, got {:?}", deps);
-        assert_eq!(dep_count, 2, "dep_count mismatch");
+        // feature.profile — exactly one internal edge to core.database via Forma deps(project(...)).
+        // External accessors (google.material, androidx.appcompat, test.junit, test.espresso)
+        // must not appear; they have no `project(...)` wrapper and no matching module exists.
+        let profile_deps = get_module_deps(&conn, "feature.profile").unwrap();
+        let profile_names: Vec<&str> = profile_deps.iter().map(|(n, _, _)| n.as_str()).collect();
+        assert_eq!(
+            profile_names,
+            vec!["core.database"],
+            "feature.profile: expected only [core.database], got {:?}",
+            profile_names
+        );
+
+        // Two consumers × one internal dep each = 2 total edges, with no duplicates.
+        assert_eq!(dep_count, 2, "expected dep_count == 2, got {}", dep_count);
+        let total_edges: i64 = conn
+            .query_row("SELECT COUNT(*) FROM module_deps", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(total_edges, 2, "module_deps row count mismatch — duplicate edge inserted?");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Add support for parsing `deps(project(":path"))` style dependency declarations in Gradle build files. This pattern is commonly used in projects using [Forma](https://github.com/formatools/forma)-like Gradle DSL or similar custom dependency management wrappers.

## Problem

ast-index only recognized standard Gradle dependency patterns:
- `implementation(project(":path"))`
- `api(project(":path"))`

Projects using custom DSL wrappers like `deps(project(":path"))` had their module dependencies ignored, resulting in empty dependency graphs.

## Solution

Added regex pattern to match `project(":path")` declarations anywhere in Gradle files:

```rust
static DEPS_PROJECT_RE: LazyLock<Regex> = LazyLock::new(|| 
    Regex::new(r#"(?m)project\s*\(\s*["']([^"']+)["']\s*\)"#).unwrap()
);
```

This catches project references inside custom wrapper functions like:
- `deps(project(":core:api"))`
- `api(project(":arch:di"))` (already worked, but now also caught by new pattern)

## Testing

Tested on large Android monorepo with 600+ modules:
- Before: `ast-index deps "some-feature.module"` → 0 dependencies
- After: `ast-index deps "some-feature.module"` → 35 dependencies

All 600+ existing tests pass.

## Related

- [Forma](https://github.com/formatools/forma) - Gradle plugin for modularized Android projects using similar DSL patterns
