### PR TITLE
Add .mts extension for TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Fast code search CLI for 34 programming languages. Native Rust implementation.
 |----------|-----------|-----------------|
 | Android | Kotlin, Java | `.kt`, `.java` |
 | iOS | Swift, Objective-C | `.swift`, `.m`, `.h` |
-| Web/Frontend | TypeScript, JavaScript | `.ts`, `.tsx`, `.js`, `.jsx`, `.mjs`, `.cjs`, `.vue`, `.svelte` |
+| Web/Frontend | TypeScript, JavaScript | `.ts`, `.tsx`, `.mts`, `.js`, `.jsx`, `.mjs`, `.cjs`, `.vue`, `.svelte` |
 | Web/Frontend | CSS, SCSS, Less | `.css`, `.pcss`, `.postcss`, `.scss`, `.less` |
 | Systems | Rust | `.rs` |
 | Systems | Zig | `.zig`, `.zon` |
@@ -637,7 +637,7 @@ exclude:
 - **Ruby callers/call-tree support** — `rb` added to scanned extensions, Ruby-specific call patterns (`.method` without parens, `:method_name` symbol refs, `method.chain`), bang/question method handling (`authenticate_user!`, `valid?`) (contributed by @melnik0v)
 - **Ruby parser improvements** — show `include`/`extend`/`prepend` in outline, `validate` (without `s`), all ActiveRecord callbacks (`after_commit`, `around_*`), multi-arg `attr_reader`/`attr_writer`/`attr_accessor`, Rails DSL (`enum`, `delegate`, `has_one_attached`, `encrypts`, `store_accessor`), `RSpec.describe` with receiver, `shared_examples`/`shared_context` (contributed by @melnik0v)
 - **Vue/Svelte outline support** — `outline` command now works for `.vue` and `.svelte` files with correct line numbers, Vue 3 Composition API (`ref`, `reactive`, `computed`, `defineProps`, `defineEmits`), lifecycle hooks, `export default` detection (contributed by @melnik0v)
-- **TypeScript/JS callers expansion** — `ts`, `tsx`, `js`, `jsx`, `vue`, `svelte` added to `callers` and `todo` command extensions
+- **TypeScript/JS callers expansion** — `ts`, `tsx`, `mts`, `js`, `jsx`, `vue`, `svelte` added to `callers` and `todo` command extensions
 
 ### 3.25.1
 - **Configuration file support** — create `.ast-index.yaml` in project root to set `project_type`, `roots`, `exclude`, `no_ignore` (CLI flags override config values)
@@ -841,7 +841,7 @@ exclude:
   - Svelte: component props extraction
   - NestJS/Angular: decorators (@Controller, @Injectable, @Component)
   - Node.js: ES modules, CommonJS
-  - File types: `.ts`, `.tsx`, `.js`, `.jsx`, `.mjs`, `.cjs`, `.vue`, `.svelte`
+  - File types: `.ts`, `.tsx`, `.mts`, `.js`, `.jsx`, `.mjs`, `.cjs`, `.vue`, `.svelte`
 - **Rust support** — index and search Rust codebases
   - Structs, enums, traits, impl blocks
   - Functions, macros, type aliases

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -257,7 +257,7 @@ ast-index --format json refs "UserRepository"
 |----------|-----------|------------|
 | Android | Kotlin, Java | `.kt`, `.java` |
 | iOS | Swift, Objective-C | `.swift`, `.m`, `.h` |
-| Web | TypeScript, JavaScript | `.ts`, `.tsx`, `.js`, `.jsx`, `.vue`, `.svelte` |
+| Web | TypeScript, JavaScript | `.ts`, `.tsx`, `.mts`, `.js`, `.jsx`, `.vue`, `.svelte` |
 | Systems | Rust, C/C++ | `.rs`, `.cpp`, `.cc`, `.c`, `.h`, `.hpp` |
 | Backend | C#, Python, Go, Scala, PHP | `.cs`, `.py`, `.go`, `.scala`, `.php` |
 | Scripting | Ruby, Perl | `.rb`, `.pm`, `.pl` |

--- a/plugin/commands/initialize-web.md
+++ b/plugin/commands/initialize-web.md
@@ -146,7 +146,7 @@ After completion, inform user:
 ## Supported File Types
 
 This initialization supports:
-- `.ts`, `.tsx` - TypeScript (including React TSX)
+- `.ts`, `.tsx`, `.mts` - TypeScript (including React TSX and ES modules)
 - `.js`, `.jsx` - JavaScript (including React JSX)
 - `.mjs`, `.cjs` - ES modules and CommonJS
 - `.vue` - Vue Single File Components

--- a/plugin/skills/ast-index/references/typescript-commands.md
+++ b/plugin/skills/ast-index/references/typescript-commands.md
@@ -1,7 +1,7 @@
 # TypeScript/JavaScript Commands Reference
 
 ast-index supports parsing and indexing TypeScript and JavaScript files:
-- `.ts`, `.tsx` - TypeScript and TSX (React)
+- `.ts`, `.tsx`, `.mts` - TypeScript and TSX (React and ES modules)
 - `.js`, `.jsx` - JavaScript and JSX (React)
 - `.mjs`, `.cjs` - ES modules and CommonJS
 - `.vue` - Vue Single File Components

--- a/src/commands/files.rs
+++ b/src/commands/files.rs
@@ -108,7 +108,7 @@ pub fn cmd_outline(root: &Path, file: &str) -> Result<()> {
     } else if ext == "java" {
         // Java — delegate to tree-sitter
         found = outline_via_treesitter(&content, crate::parsers::FileType::Java, &[SymbolKind::Import, SymbolKind::Annotation])?;
-    } else if ext == "ts" || ext == "tsx" || ext == "js" || ext == "jsx" {
+    } else if ext == "ts" || ext == "tsx" || ext == "mts" || ext == "js" || ext == "jsx" {
         // TypeScript/JavaScript — delegate to tree-sitter
         found = outline_via_treesitter(&content, crate::parsers::FileType::TypeScript, &[SymbolKind::Import])?;
     } else if ext == "vue" {

--- a/src/commands/grep.rs
+++ b/src/commands/grep.rs
@@ -25,31 +25,31 @@ use regex::Regex;
 use super::{search_files_limited, relative_path};
 
 /// All source code extensions (for grep-based commands: todo, search, callers, etc.)
-pub const ALL_SOURCE_EXTENSIONS: [&str; 57] = [
-    "kt", "java", "swift", "m", "h",           // Mobile
-    "dart",                                      // Flutter
-    "gd",                                        // GDScript (Godot)
-    "pm", "pl", "t", "rb",                      // Scripting
-    "ts", "tsx", "js", "jsx", "mjs", "cjs",    // JavaScript/TypeScript
-    "vue", "svelte",                             // Web frameworks
-    "css", "pcss", "postcss", "scss", "less",  // CSS family
-    "py",                                        // Python
-    "go",                                        // Go
-    "rs",                                        // Rust
-    "zig",                                       // Zig
-    "cs",                                        // C#
-    "cpp", "cc", "c", "hpp",                    // C++
-    "scala", "sc",                               // Scala
-    "php", "phtml",                              // PHP
-    "groovy", "gradle",                          // Groovy
-    "lua",                                       // Lua
-    "ex", "exs",                                 // Elixir
-    "sh", "bash", "zsh",                         // Shell
-    "sql",                                       // SQL
-    "r", "R",                                    // R
-    "bsl", "os",                                 // BSL
-    "lisp", "lsp", "cl", "asd",                 // Common Lisp
-    "proto", "wsdl", "xsd",                      // Schema
+pub const ALL_SOURCE_EXTENSIONS: [&str; 58] = [
+    "kt", "java", "swift", "m", "h",                // Mobile
+    "dart",                                         // Flutter
+    "gd",                                           // GDScript (Godot)
+    "pm", "pl", "t", "rb",                          // Scripting
+    "ts", "tsx", "mts", "js", "jsx", "mjs", "cjs",  // JavaScript/TypeScript
+    "vue", "svelte",                                // Web frameworks
+    "css", "pcss", "postcss", "scss", "less",       // CSS family
+    "py",                                           // Python
+    "go",                                           // Go
+    "rs",                                           // Rust
+    "zig",                                          // Zig
+    "cs",                                           // C#
+    "cpp", "cc", "c", "hpp",                        // C++
+    "scala", "sc",                                  // Scala
+    "php", "phtml",                                 // PHP
+    "groovy", "gradle",                             // Groovy
+    "lua",                                          // Lua
+    "ex", "exs",                                    // Elixir
+    "sh", "bash", "zsh",                            // Shell
+    "sql",                                          // SQL
+    "r", "R",                                       // R
+    "bsl", "os",                                    // BSL
+    "lisp", "lsp", "cl", "asd",                     // Common Lisp
+    "proto", "wsdl", "xsd",                         // Schema
 ];
 
 /// Trailing word boundary: `\b` for normal names, empty for Ruby bang/question methods

--- a/src/commands/project_info.rs
+++ b/src/commands/project_info.rs
@@ -103,7 +103,7 @@ fn detect_project_type(conn: &rusqlite::Connection) -> String {
                     WHEN path LIKE '%.swift' THEN 'swift'
                     WHEN path LIKE '%.m' OR path LIKE '%.mm' THEN 'objc'
                     WHEN path LIKE '%.dart' THEN 'dart'
-                    WHEN path LIKE '%.ts' OR path LIKE '%.tsx' THEN 'ts'
+                    WHEN path LIKE '%.ts' OR path LIKE '%.tsx' OR path LIKE '%.mts' THEN 'ts'
                     WHEN path LIKE '%.js' OR path LIKE '%.jsx' THEN 'js'
                     WHEN path LIKE '%.py' THEN 'py'
                     WHEN path LIKE '%.go' THEN 'go'

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -473,7 +473,7 @@ impl FileType {
             "rb" => Some(FileType::Ruby),
             "cs" => Some(FileType::CSharp),
             "dart" => Some(FileType::Dart),
-            "ts" | "tsx" | "js" | "jsx" | "mjs" | "cjs" => Some(FileType::TypeScript),
+            "ts" | "tsx" | "mts" | "js" | "jsx" | "mjs" | "cjs" => Some(FileType::TypeScript),
             "vue" => Some(FileType::Vue),
             "svelte" => Some(FileType::Svelte),
             "scala" | "sc" => Some(FileType::Scala),
@@ -967,6 +967,7 @@ mod tests {
         assert!(is_supported_extension("swift"));
         assert!(is_supported_extension("ts"));
         assert!(is_supported_extension("tsx"));
+        assert!(is_supported_extension("mts"));
         assert!(is_supported_extension("py"));
         assert!(is_supported_extension("go"));
         assert!(is_supported_extension("rs"));
@@ -1203,6 +1204,7 @@ mod tests {
         assert_eq!(FileType::from_extension("dart"), Some(FileType::Dart));
         assert_eq!(FileType::from_extension("ts"), Some(FileType::TypeScript));
         assert_eq!(FileType::from_extension("tsx"), Some(FileType::TypeScript));
+        assert_eq!(FileType::from_extension("mts"), Some(FileType::TypeScript));
         assert_eq!(FileType::from_extension("vue"), Some(FileType::Vue));
         assert_eq!(FileType::from_extension("svelte"), Some(FileType::Svelte));
         assert_eq!(FileType::from_extension("php"), Some(FileType::Php));

--- a/src/parsers/typescript.rs
+++ b/src/parsers/typescript.rs
@@ -1,7 +1,7 @@
 //! TypeScript/JavaScript parser for symbol extraction
 //!
 //! Supports:
-//! - TypeScript (.ts, .tsx)
+//! - TypeScript (.ts, .tsx, .mts)
 //! - JavaScript (.js, .jsx, .mjs, .cjs)
 //! - Vue SFC (.vue)
 //! - Svelte (.svelte)


### PR DESCRIPTION
Ensure that TypeScript module [.mts files](https://www.typescriptlang.org/docs/handbook/modules/reference.html#module-format-detection) get indexed as TypeScript.