### PR TITLE
fix(indexer): set rayon worker stack to 32 MB to prevent crashes on deep AST recursion

### DIFF
--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -11,6 +11,14 @@ use std::time::SystemTime;
 use crate::db;
 use crate::parsers::{self, ParsedRef, ParsedSymbol};
 
+/// Per-worker stack size for the rayon parsing pool.
+///
+/// Tree-sitter parsers recurse on each node of the AST; pathological inputs
+/// (Dart SDK test corpus, deeply nested generics, long expression chains) can
+/// overflow the Rust default (≈ 2 MB on most platforms). 32 MB gives plenty
+/// of headroom without committing the pages eagerly.
+const RAYON_WORKER_STACK_SIZE: usize = 32 * 1024 * 1024;
+
 /// Sorted module lookup for efficient longest-prefix matching.
 /// Entries sorted by path length descending so the longest (most specific) match is found first.
 struct ModuleLookup {
@@ -982,6 +990,7 @@ pub fn index_directory_scoped(conn: &mut Connection, root: &Path, walk_dir: &Pat
     if verbose { eprintln!("[verbose] using {} threads for parsing", num_threads); }
     let pool = rayon::ThreadPoolBuilder::new()
         .num_threads(num_threads)
+        .stack_size(RAYON_WORKER_STACK_SIZE)
         .build()
         .map_err(|e| anyhow::anyhow!("Failed to build thread pool: {}", e))?;
 
@@ -1279,6 +1288,7 @@ pub fn update_directory_incremental(
             .unwrap_or(32);
         let pool = rayon::ThreadPoolBuilder::new()
             .num_threads(num_threads)
+            .stack_size(RAYON_WORKER_STACK_SIZE)
             .build()
             .map_err(|e| anyhow::anyhow!("Failed to build thread pool: {}", e))?;
 
@@ -2976,6 +2986,7 @@ pub fn index_node_modules_dts(conn: &mut Connection, root: &Path, progress: bool
 
     let pool = rayon::ThreadPoolBuilder::new()
         .num_threads(num_threads)
+        .stack_size(RAYON_WORKER_STACK_SIZE)
         .build()
         .map_err(|e| anyhow::anyhow!("Failed to build thread pool: {}", e))?;
 


### PR DESCRIPTION
## Problem

`ast-index rebuild` crashes with

    thread '<unknown>' has overflowed its stack
    fatal runtime error: stack overflow

(exit 134) on large Dart/Flutter codebases. The crash reliably reproduces when
the index walks the Dart SDK test corpus, which contains files specifically
written to stress the parser (deeply nested generics, pathological recursion).
The same class of crash is reachable from any tree-sitter grammar that can
recurse deeply on a single input — Dart is just the easiest trigger.

Root cause: the rayon worker pool inherits the Rust default thread stack
(≈ 2 MB on macOS), which is too small for the recursive descent of these
parsers.

## Fix

Set `.stack_size(32 * 1024 * 1024)` on all three `rayon::ThreadPoolBuilder`
instances in `src/indexer.rs`.

This is language-agnostic: it benefits every tree-sitter grammar that can
recurse deeply (Dart, C++, Rust, TypeScript, etc.), not just Dart.

## Validation

After patch, a previously-crashing 162 049-file Flutter project rebuilds
cleanly in 6m 11s on M4 Pro (8 threads), producing a 929 MB index with
1 241 066 symbols across 1 473 modules and 0 failed files.

Per-language smoke tests pass on smaller scopes (verified C++, Go, Kotlin,
Dart sub-projects — all index without regression in symbol counts).

## Risk

Memory: 32 MB × 8 worker threads = 256 MB worst-case worker stack allocation
on top of normal heap. Acceptable on any modern dev machine. Stack allocation
is lazy — pages are only committed when used, so typical files cost nothing.

No CLI surface change. No behavioral change for codebases that didn't crash.
