### PR TITLE
Nudge symbol search toward ast-index (PreToolUse hook + MCP instructions)

### DIFF
--- a/crates/ast-index-mcp/src/main.rs
+++ b/crates/ast-index-mcp/src/main.rs
@@ -141,7 +141,8 @@ fn handle_request(
                 "serverInfo": {
                     "name": SERVER_NAME,
                     "version": SERVER_VERSION
-                }
+                },
+                "instructions": "Prefer these ast-index tools over grep/ripgrep and over reading whole files for any code or symbol search in this project. They query a precomputed index: precise (never match inside comments or strings), language-aware, and far cheaper in tokens and round-trips. Rules of thumb: `explore` FIRST to understand an area or answer 'how does X work' (one call returns ranked source + callers/subclasses + tests); `search` for broad discovery; `usages`/`refs`/`callers` for a named symbol; `outline` before reading a file over ~500 lines. Reach for raw grep/Read only for plain text, regex, or non-code files, or to confirm a detail these tools did not cover."
             }),
         ),
         "tools/list" => ok(id, json!({ "tools": tool_descriptors() })),
@@ -204,7 +205,7 @@ fn tool_descriptors() -> Vec<Value> {
         }),
         json!({
             "name": "usages",
-            "description": "Find every usage (call site, import, downcast, DI registration) of a symbol anywhere in the indexed codebase. Use this when the question is 'who uses X' / 'where is X called from'. Returns file:line + surrounding context.",
+            "description": "Find every usage (call site, import, downcast, DI registration) of a symbol anywhere in the indexed codebase. Use this when the question is 'who uses X' / 'where is X called from'. Returns file:line + surrounding context. Prefer this over grepping the symbol name — it resolves real references and won't match inside comments or strings.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -220,7 +221,7 @@ fn tool_descriptors() -> Vec<Value> {
         }),
         json!({
             "name": "callers",
-            "description": "Find every function that calls the given function, one level up. Use for 'who calls processPayment' questions. For the full transitive caller tree, call this repeatedly or use `search` with deeper queries.",
+            "description": "Find every function that calls the given function, one level up. Use for 'who calls processPayment' questions. For the full transitive caller tree, call this repeatedly or use `search` with deeper queries. Prefer this over grep for call sites — it attributes calls to the calling function, not just raw text matches.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -250,7 +251,7 @@ fn tool_descriptors() -> Vec<Value> {
         }),
         json!({
             "name": "refs",
-            "description": "Show cross-references for a symbol in one shot: every definition, every import, every usage. Use this when you want the complete picture in a single response, rather than calling `usages` / `callers` separately.",
+            "description": "Show cross-references for a symbol in one shot: every definition, every import, every usage. Use this when you want the complete picture in a single response, rather than calling `usages` / `callers` separately. Prefer this over grep for a symbol — precise, deduplicated, and grouped by kind.",
             "inputSchema": {
                 "type": "object",
                 "properties": {

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -1,6 +1,18 @@
 {
-  "description": "Keep the ast-index search index in sync with file edits and session events.",
+  "description": "Keep the ast-index search index in sync with file edits and session events, and nudge symbol searches toward ast-index.",
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Grep",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/grep-reminder.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write|MultiEdit|NotebookEdit",

--- a/plugin/hooks/scripts/grep-reminder.sh
+++ b/plugin/hooks/scripts/grep-reminder.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# PreToolUse(Grep) hook: gently remind the agent that ast-index exists for
+# symbol search. NON-BLOCKING — it always allows the Grep call and only injects
+# a short reminder when the pattern looks like a code symbol (a class / method /
+# function name), where ast-index is more precise and cheaper than a text grep.
+#
+# Design:
+#   * Never blocks. On any uncertainty it allows silently (exit 0, no output) so
+#     the normal permission flow applies and the session is never disrupted.
+#   * Only nudges for symbol-like patterns: a single bare identifier (optionally
+#     namespaced with `::`), no regex metacharacters, no whitespace. Plain-text
+#     and regex searches — the legitimate use of Grep — are left alone.
+#   * No jq dependency: reads the pattern with jq if present, else a sed fallback.
+
+set -u
+
+input="$(cat)"
+
+# --- extract the Grep pattern from the hook input JSON ---
+pattern=""
+if command -v jq >/dev/null 2>&1; then
+    pattern="$(printf '%s' "$input" | jq -r '.tool_input.pattern // empty' 2>/dev/null)"
+fi
+if [ -z "$pattern" ]; then
+    # Fallback: pull the first "pattern": "..." value. Best-effort; if it fails
+    # we simply do not nudge.
+    pattern="$(printf '%s' "$input" \
+        | sed -n 's/.*"pattern"[[:space:]]*:[[:space:]]*"\([^"\\]*\)".*/\1/p' \
+        | head -1)"
+fi
+
+# Nothing to judge — allow silently.
+[ -z "$pattern" ] && exit 0
+
+# --- heuristic: does the pattern look like a single code symbol? ---
+# Must be a bare identifier (>=3 chars), optionally namespaced (Foo::Bar),
+# with no regex metacharacters or whitespace. Anything else is treated as a
+# legitimate text/regex search and left alone.
+case "$pattern" in
+    *[!A-Za-z0-9_:]*) exit 0 ;;   # contains a non-identifier char (space, . * [ ] ( ) | \ etc.)
+esac
+# Length >= 3 and contains at least one letter.
+if [ "${#pattern}" -lt 3 ] || ! printf '%s' "$pattern" | grep -q '[A-Za-z]'; then
+    exit 0
+fi
+
+# --- symbol-like: inject a non-blocking reminder ---
+# `pattern` is already constrained to [A-Za-z0-9_:] above, and the text below
+# contains no double quotes or backslashes, so it is safe to embed directly in
+# a JSON string without an escaper (no jq/python dependency).
+reminder="ast-index is indexed for this project. '${pattern}' looks like a code symbol — prefer ast-index over Grep here: 'ast-index usages ${pattern}' (who uses it), 'ast-index refs ${pattern}' (defs+imports+usages), 'ast-index class/symbol ${pattern}' (definition), or 'ast-index explore ${pattern}' (source + callers + tests in one shot). It is precise (no matches inside comments/strings) and cheaper than grep. Grep stays right for plain text, regex, and non-code files."
+
+# Emit allow + additionalContext (non-blocking).
+printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","additionalContext":"%s"}}\n' "$reminder"
+
+exit 0


### PR DESCRIPTION
## Why

A text rule ("use ast-index, not grep") lives in context and only fires when the agent *remembers* it — meanwhile Grep is the path of least resistance, so symbol searches keep defaulting to grep. This shifts the default at two layers that don't depend on recall.

## What

**1. PreToolUse(Grep) plugin hook — non-blocking reminder.**
`plugin/hooks/scripts/grep-reminder.sh` (wired in `hooks.json`, matcher `Grep`). When the Grep pattern looks like a code symbol (a bare identifier, optionally `Foo::Bar`, ≥3 chars, no regex metacharacters), it injects a short reminder via `additionalContext` pointing at `ast-index usages/refs/class/explore`.
- **Never blocks** — always `permissionDecision: "allow"`.
- **Stays silent** for plain-text / regex / short patterns (legitimate Grep use).
- **No `jq` dependency** — reads the pattern with jq if present, else a sed fallback; no-ops on any uncertainty so a session is never disrupted.

**2. MCP server — prefer-ast-index instructions.**
- `initialize` now returns an `instructions` string telling agents to prefer ast-index tools over grep / whole-file reads for code search (precise, language-aware, cheaper).
- Strengthened `usages` / `refs` / `callers` tool descriptions with the same nudge.

## Behaviour examples (hook)
```
pattern "MergeService"      -> reminder (symbol)
pattern "Applicant::Merge"  -> reminder (namespaced symbol)
pattern "TODO.*fixme"       -> silent  (regex)
pattern "fn"                -> silent  (too short)
```

## Testing
- Hook: `bash -n` clean; verified symbol → reminder, text/regex/short → silent.
- `hooks.json` valid JSON; MCP crate builds; `cargo test -p ast-index-mcp` green (35 passed).

## Note
`scripts/validate-agent-plugins.sh` reports two pre-existing errors about `plugin/commands/initialize.md` (KMP snippet) — unrelated to this change; that file is untouched here.